### PR TITLE
HTML -> Span improvements, Japanese Display, Debug Timers

### DIFF
--- a/scripts/ruby_fixer.py
+++ b/scripts/ruby_fixer.py
@@ -1,0 +1,209 @@
+import sqlite3
+import sys
+import shutil
+import os
+import time
+import zipfile
+import tempfile
+import unittest
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+from multiprocessing import Pool, cpu_count
+
+def simplify_ruby_html(note_data):
+    """
+    Worker function to simplify HTML. This version correctly handles
+    malformed ruby tags and filters out link-only list items.
+    """
+    # The first element of the tuple is the note_id.
+    # The second is the fields string.
+    note_id, flds = note_data
+    fields = flds.split('\x1f')
+    
+    # Ensure the field exists before trying to access it
+    if len(fields) < 2:
+        return None
+    
+    original_html = fields[1]
+
+    if not original_html.strip():
+        return None
+
+    # --- HTML Parsing Logic ---
+    soup = BeautifulSoup(original_html, 'html.parser')
+    simplified_parts = []
+    for element in soup.find_all(recursive=False):
+        if element.name == 'h3':
+            simplified_parts.append(f"<h3>{element.get_text().strip()}</h3>")
+        elif element.name == 'p':
+            paragraph_content = ""
+            for content in element.contents:
+                if content.name == 'ruby':
+                    rt_tag = content.find('rt')
+                    rb_tag = content.find('rb')
+                    if rb_tag:
+                        if rt_tag and rt_tag.find_parent() == rb_tag:
+                            rt_tag.extract()
+                        rt_text = rt_tag.get_text() if rt_tag else ""
+                        rb_text = rb_tag.get_text()
+                        if rt_text.strip():
+                            paragraph_content += f"<ruby><rb>{rb_text}</rb><rt>{rt_text}</rt></ruby>"
+                        else:
+                            paragraph_content += rb_text
+                elif content.string:
+                    stripped_string = content.string.strip()
+                    if stripped_string:
+                        paragraph_content += stripped_string
+            simplified_parts.append(f"<p>{paragraph_content}</p>")
+        elif element.name == 'ul':
+            # NEW LOGIC: Filter list items
+            valid_list_items = []
+            for li in element.find_all('li'):
+                # Check if the list item is "link-only"
+                # This is true if its only non-whitespace content is a single <a> tag.
+                non_whitespace_children = [c for c in li.contents if not (isinstance(c, str) and c.strip() == '')]
+                
+                is_link_only = len(non_whitespace_children) == 1 and non_whitespace_children[0].name == 'a'
+                
+                if not is_link_only:
+                    valid_list_items.append(f"<li>{li.get_text().strip()}</li>")
+
+            # Only add the <ul> if it's not empty after filtering
+            if valid_list_items:
+                simplified_parts.append(f"<ul>{''.join(valid_list_items)}</ul>")
+            # END OF NEW LOGIC
+            
+    cleaned_html = "\n".join(simplified_parts)
+    # --- End HTML Logic ---
+
+    if original_html != cleaned_html:
+        fields[1] = cleaned_html
+        new_flds = '\x1f'.join(fields)
+        return (note_id, new_flds)
+            
+    return None
+
+
+def clean_anki2_database(db_path):
+    """Runs the cleaning logic on the provided .anki2 database file using a process pool."""
+    try:
+        with sqlite3.connect(db_path) as con:
+            cur = con.cursor()
+            cur.execute("SELECT id, flds FROM notes")
+            notes_to_process = cur.fetchall()
+
+        if not notes_to_process:
+            print("No notes found in the database.")
+            return
+
+        print(f"Found {len(notes_to_process)} notes. Processing in parallel on {cpu_count()} cores...")
+        
+        with Pool() as pool:
+            results = list(tqdm(pool.imap_unordered(simplify_ruby_html, notes_to_process), 
+                                total=len(notes_to_process), 
+                                desc="Cleaning notes"))
+
+        updates_to_apply = [res for res in results if res is not None]
+
+        if not updates_to_apply:
+            print("No notes needed cleaning.")
+            return
+            
+        print(f"Applying {len(updates_to_apply)} updates to the database...")
+        with sqlite3.connect(db_path) as con:
+            cur = con.cursor()
+            timestamp = int(time.time())
+            updates_with_timestamp = [(flds, timestamp, note_id) for note_id, flds in updates_to_apply]
+            cur.executemany("UPDATE notes SET flds = ?, mod = ? WHERE id = ?", updates_with_timestamp)
+            print(f"Updated {len(updates_to_apply)} notes in the database.")
+
+    except sqlite3.Error as e:
+        print(f"Database error during cleaning: {e}")
+        raise
+
+def process_apkg_file(apkg_path):
+    """Unpacks, cleans (in parallel), and repacks an .apkg file."""
+    output_path = apkg_path.replace('.apkg', '_cleaned.apkg')
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        try:
+            print(f"Unpacking {os.path.basename(apkg_path)}...")
+            with zipfile.ZipFile(apkg_path, 'r') as z:
+                z.extractall(temp_dir)
+
+            db_file_path = next((os.path.join(temp_dir, f) for f in os.listdir(temp_dir) if f.endswith('.anki2')), None)
+            if not db_file_path:
+                print("Error: Could not find an .anki2 database in the package.")
+                return
+            clean_anki2_database(db_file_path)
+
+            print(f"Repacking into {os.path.basename(output_path)}...")
+            with zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED) as z_out:
+                files_to_zip = [os.path.join(r, f) for r, _, files in os.walk(temp_dir) for f in files]
+                for file_path in tqdm(files_to_zip, desc="Repacking files", unit="file"):
+                    arcname = os.path.relpath(file_path, temp_dir)
+                    z_out.write(file_path, arcname)
+            
+            print(f"\nSuccess! Cleaned deck saved to: {output_path}")
+
+        except Exception as e:
+            print(f"\nAn error occurred during processing: {e}")
+            print("No changes were saved.")
+
+# --- Unit Test Suite ---
+class TestHtmlSimplification(unittest.TestCase):
+    def run_test_on_html(self, original_html):
+        note_data = (1, f"Front\x1f{original_html}")
+        result = simplify_ruby_html(note_data)
+        return result[1].split('\x1f')[1] if result else original_html
+
+    def test_fix_malformed_ruby(self):
+        """Tests the specific bugfix for unclosed <rb> tags."""
+        html = "<p><ruby><rb>結婚<rt>けっこん</ruby></p>"
+        expected = "<p><ruby><rb>結婚</rb><rt>けっこん</rt></ruby></p>"
+        self.assertEqual(self.run_test_on_html(html), expected)
+
+    def test_removes_link_only_list(self):
+        """Tests that a <ul> containing only links is completely removed."""
+        html = "<h3>Actions:</h3><ul><li><a href='#'>Google</a></li><li><a href='#'>Midori</a></li></ul>"
+        expected = "<h3>Actions:</h3>"
+        self.assertEqual(self.run_test_on_html(html), expected)
+
+    def test_keeps_mixed_content_list(self):
+        """Tests that a <ul> with mixed content is kept, but links are stripped."""
+        html = "<ul><li>Keep this.</li><li><a href='#'>Remove this</a></li></ul>"
+        expected = "<ul><li>Keep this.</li></ul>"
+        self.assertEqual(self.run_test_on_html(html), expected)
+
+    def test_full_example_with_link_filtering(self):
+        """Tests a complete, complex field with the new link filtering."""
+        html = """<h3>Reading:</h3>
+<p><ruby><rb>彼<rt>かれ</ruby></p>
+<h3>Translation:</h3>
+<ul><li>His shoes are brown.</li></ul>
+<h3>Actions:</h3>
+<ul><li><a href="#">Google Translate</a></li></ul>"""
+        expected = """<h3>Reading:</h3>
+<p><ruby><rb>彼</rb><rt>かれ</rt></ruby></p>
+<h3>Translation:</h3>
+<ul><li>His shoes are brown.</li></ul>
+<h3>Actions:</h3>"""
+        self.assertEqual(self.run_test_on_html(html), expected)
+
+    def test_no_changes_needed(self):
+        """Tests that HTML without relevant tags is returned as None by the worker."""
+        note_data = (1, "Front\x1f<p>Hello world</p>")
+        self.assertIsNone(simplify_ruby_html(note_data))
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 and sys.argv[1] == '--test':
+        print("Running unit tests...")
+        sys.argv.pop(1)
+        unittest.main(verbosity=2)
+    elif len(sys.argv) == 2:
+        process_apkg_file(sys.argv[1])
+    else:
+        print("Usage:")
+        print(f"  python {sys.argv[0]} <path_to_deck.apkg>")
+        print(f"  python {sys.argv[0]} --test")
+        sys.exit(1)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,27 @@
+use std::time::Instant;
+
+/// A simple RAII timer for performance tracing.
+/// When created, it notes the start time.
+/// When it goes out of scope (at the end of a block), it automatically
+/// prints the time elapsed since its creation.
+pub struct Tracer {
+    name: &'static str,
+    start_time: Instant,
+}
+
+impl Tracer {
+    pub fn new(name: &'static str) -> Self {
+        Tracer {
+            name,
+            start_time: Instant::now(),
+        }
+    }
+}
+
+impl Drop for Tracer {
+    fn drop(&mut self) {
+        let elapsed = self.start_time.elapsed();
+        // Print in a human-readable format (e.g., milliseconds or microseconds)
+        println!("[Trace] {}: {:.2?}", self.name, elapsed);
+    }
+}

--- a/src/deck/html_parser.rs
+++ b/src/deck/html_parser.rs
@@ -10,6 +10,7 @@ pub struct TextSpan {
     pub is_italic: bool,
     pub is_ruby_base: bool,
     pub ruby_text: Option<String>,
+    pub is_newline: bool,
 }
 
 pub fn parse_html_to_spans(html: &str) -> Vec<TextSpan> {
@@ -35,7 +36,6 @@ pub fn parse_html_to_spans(html: &str) -> Vec<TextSpan> {
     for h in queue {
         process_node(h, parser, &mut spans, TextSpan::default());
     }
-    println!("{:?}", spans);
     spans
 }
 
@@ -127,6 +127,7 @@ fn process_node(
                     is_ruby_base: true,
                     ruby_text: ruby_text_content,
                     new_text_block: false,
+                    is_newline: false,
                 });
             }
         } else if !is_br { // Normal element, process children recursively, if not a <br> or <ruby>

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,11 @@ use sdl2::keyboard::Keycode;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 
-// Modules for our application
 mod deck;
 mod scheduler;
 mod ui;
 mod storage;
 
-// Bring our structs and traits into scope
 use deck::{Card, Deck};
 use scheduler::{Rating, Scheduler, Sm2Scheduler};
 use ui::{CanvasManager, FontManager, font::TextLayout, sprite::Sprite};
@@ -52,10 +50,7 @@ struct AppState<'a> {
 pub fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 { return Err(format!("Usage: {} <path/to/deck.apkg>", args.get(0).unwrap_or(&"cardbrick".to_string()))); }
-    // Use PathBuf for an owned path
-    let deck_path = PathBuf::from(&args[1]); 
-    
-    // --- FIX: Create deck_id BEFORE deck_path is moved ---
+    let deck_path = PathBuf::from(&args[1]);     // Use PathBuf for an owned path
     let deck_id = deck_path
         .file_stem()
         .and_then(|s| s.to_str())
@@ -64,7 +59,7 @@ pub fn main() -> Result<(), String> {
 
     let sdl_context = sdl2::init()?;
     let video_subsystem = sdl_context.video()?;
-    sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");
+    sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1"); // Enable anti-aliasing et al
     let ttf_context = sdl2::ttf::init().map_err(|e| e.to_string())?;
 
     let window = video_subsystem.window("CardBrick v0.1", 1024, 768).position_centered().build().map_err(|e| e.to_string())?;
@@ -74,10 +69,13 @@ pub fn main() -> Result<(), String> {
     let (tx, rx) = mpsc::channel::<LoaderMessage>();
     thread::spawn(move || { deck::loader::load_apkg(&deck_path, tx); });
 
+    // TODO: Move the font into a local directory.
     let font_path = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc";
 
     // Initialize FontManager instances first, as they are needed for loading_layout
     let mut font_manager = FontManager::new(&ttf_context, font_path, 32)?;
+
+    // This needs to be mutable because we want the user to be able to change the size of the font among other things.
     let mut small_font_manager = FontManager::new(&ttf_context, font_path, 24)?;
     let mut hint_font_manager = FontManager::new(&ttf_context, font_path, 20)?;
 

--- a/src/ui/font.rs
+++ b/src/ui/font.rs
@@ -2,11 +2,12 @@
 // Manages loading fonts, calculating text layouts, and rendering text.
 
 use sdl2::pixels::Color;
+use std::collections::VecDeque;
 use sdl2::rect::Rect;
 use sdl2::render::Canvas;
 use sdl2::ttf::{Font, Sdl2TtfContext, FontStyle};
 use sdl2::video::Window;
-
+use crate::Tracer;
 use crate::deck::html_parser::TextSpan;
 
 /// Holds a pre-calculated text layout for efficient rendering and scrolling.
@@ -43,181 +44,306 @@ impl<'a, 'b> FontManager<'a, 'b> {
         result
     }
 
-    /// Calculates how to wrap text and returns a layout object.
-    /// This processes TextSpans, handles explicit newlines, and implements
-    /// character-by-character wrapping to ensure content fits within max_width
-    pub fn layout_text(&mut self, spans: &[TextSpan], max_width: u32) -> Result<TextLayout, String> {
+    /// Finds the character index to split a TextSpan so it fits within the available width.
+    /// This is the efficient binary search method.
+    fn find_split_index(&mut self, span: &TextSpan, available_width: u32) -> Result<usize, String> {
+        let text = &span.text;
+        let mut low = 0;
+        let mut high = text.chars().count();
+        let mut best_fit_char_index = 0;
+
+        // Binary search to find the maximum number of characters that fit.
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            if mid == 0 {
+                low = mid + 1;
+                continue;
+            }
+
+            let substring: String = text.chars().take(mid).collect();
+            let (substr_width, _) = self.size_of_text_with_style(&substring, span.is_bold, span.is_italic)?;
+
+            if substr_width <= available_width {
+                best_fit_char_index = mid; // This substring fits.
+                low = mid + 1;             // Try a longer one.
+            } else {
+                high = mid - 1;            // Substring is too long.
+            }
+        }
+
+        // Convert the character count back to a byte index for `split_at`.
+        Ok(text.char_indices().nth(best_fit_char_index).map_or(0, |(idx, _)| idx))
+    }
+
+
+    pub fn layout_text_binary(&mut self, spans: &[TextSpan], max_width: u32) -> Result<TextLayout, String> {
+        #[cfg(debug_assertions)]
+        let _layout_tracer = Tracer::new("Load Card Layout");
+
+        // --- STAGE 1: Pre-processing (Your excellent suggestion) ---
+        let mut processed_spans = VecDeque::new();
+        for span in spans {
+            let mut parts = span.text.split('\n').peekable();
+            while let Some(part) = parts.next() {
+                if !part.is_empty() {
+                    let mut text_span = span.clone();
+                    text_span.text = part.to_string();
+                    text_span.is_newline = false;
+                    processed_spans.push_back(text_span);
+                }
+                if parts.peek().is_some() {
+                    let mut newline_span = span.clone();
+                    newline_span.text = String::new();
+                    newline_span.is_newline = true;
+                    processed_spans.push_back(newline_span);
+                }
+            }
+        }
+
+        // --- STAGE 2: Corrected Layout Engine ---
         let mut lines: Vec<Vec<TextSpan>> = Vec::new();
         let mut current_line_spans: Vec<TextSpan> = Vec::new();
         let mut current_line_width = 0;
         let line_height = self.font.height();
-        let mut overflow = false;
 
-        // Ensure at least one line to start with if spans are empty or to handle leading newlines
-        if spans.is_empty() {
-            lines.push(Vec::new());
-            return Ok(TextLayout { lines, total_height: line_height as i32, scroll_offset: 0 });
-        }
-
-        for span in spans {
-
-            // Get the text from the span. We will add it step-by-step to the current list of spans in this line.
-            // If the line gets too long, we will split this span into two and add the current "line spans" to the line array.
-
-            if span.new_text_block {
-                if !current_line_spans.is_empty() {
-                    lines.push(current_line_spans);
-                    current_line_spans = Vec::new();
-                    current_line_width = 0;
-                }
+        while let Some(mut span) = processed_spans.pop_front() {
+            // Handle dedicated newline spans from our pre-processing.
+            if span.is_newline {
+                lines.push(current_line_spans);
+                current_line_spans = Vec::new();
+                current_line_width = 0;
+                continue;
             }
 
+            let space_left = max_width.saturating_sub(current_line_width);
+            let (span_width, _) = self.size_of_text_with_style(&span.text, span.is_bold, span.is_italic)?;
 
-            let mut remaining_text_in_span: String = span.text.clone().trim().to_string();
+            if span_width <= space_left {
+                // The whole span fits on the current line.
+                current_line_spans.push(span);
+                current_line_width += span_width;
+            } else {
+                // The span does NOT fit. We must split it.
+                let split_byte_index = self.find_split_index(&span, space_left)?;
 
-            // Loop while there's text left in the current span to process
-            while !remaining_text_in_span.is_empty() {
-                let mut line_segment_chars_to_add = String::new(); // Reset the chars to add to the line from the current span.
-                let mut chars_consumed_from_remaining = 0; // Chars in remaining_text_in_span that were processed for this line
-                let mut current_segment_width_temp = 0; // Width of `line_segment_chars_to_add`
-                let mut hard_break_encountered = false;
+                if split_byte_index > 0 {
+                    // Part of the span fits.
+                    let (fits, remaining) = span.text.split_at(split_byte_index);
+                    
+                    // Add the part that fits to the current line.
+                    let mut fit_span = span.clone();
+                    fit_span.text = fits.to_string();
+                    current_line_spans.push(fit_span);
+                    
+                    // Put the remainder back at the front of the queue to be processed next.
+                    span.text = remaining.to_string();
+                    processed_spans.push_front(span);
 
-                // Iterate through characters of the remaining span text to build a line segment, until we run out of characters or space.
-                for char_c in remaining_text_in_span.chars() {
-                    if char_c == '\n' {
-                        // Found a hard newline character, break the line here
-                        hard_break_encountered = true;
-                        chars_consumed_from_remaining += 1; // Consume the newline char
-                        break; // Stop accumulating chars for this line segment
-                    }
-
-                    let (char_width, _) = self.size_of_text_with_style(
-                        &char_c.to_string(),
-                        span.is_bold, // Use original span's style for width calculation
-                        span.is_italic
-                    )?;
-
-                    let potential_line_width = current_line_width + current_segment_width_temp + char_width;
-                    if potential_line_width <= max_width {
-                        line_segment_chars_to_add.push(char_c);
-                        current_segment_width_temp += char_width;
-                        chars_consumed_from_remaining += 1; // Count char taken from remaining_text_in_span
-
-                        println!("Characters to add; {:?}", line_segment_chars_to_add);
-                    } else {
-                        // Overflow.  Perform line processing and then return to the remaining characters via the for loop.
-                        overflow = true;
-                        break;
-                    }
+                } else {
+                    // Not even a single character fits on the current line.
+                    // (This happens if `current_line_width` is > 0).
+                    // So, we put the whole span back and start a new line.
+                    processed_spans.push_front(span);
                 }
 
-                println!("{:?}", line_segment_chars_to_add);
-                println!("{:?}", chars_consumed_from_remaining);
-                println!("{:?}", current_segment_width_temp);
-                println!("{:?}", hard_break_encountered);
-
-                // This happens when a hard break (\n) is encountered, or a character is encountered, or we run out of characters in this current span.
-
-                let requires_newline = hard_break_encountered || overflow;
-
-                if requires_newline {
-                    if hard_break_encountered {
-                        println!("LINEBREAK: Hard Break encountered", );
-                        if !line_segment_chars_to_add.is_empty() {
-                            let span = TextSpan {
-                                text: line_segment_chars_to_add.clone(),
-                                is_bold: span.is_bold,
-                                is_italic: span.is_italic,
-                                is_ruby_base: span.is_ruby_base,
-                                ruby_text: span.ruby_text.clone(),
-                                new_text_block: false,
-                            };
-                            println!("{:?}", span);
-                            current_line_spans.push(span);
-                            current_line_width += current_segment_width_temp; // Use the accumulated width for efficiency
-                        }
-                        if !current_line_spans.is_empty() {
-                            lines.push(current_line_spans);
-                            current_line_spans = Vec::new();
-                            current_line_width = 0;
-                        } else {
-                            lines.push(Vec::new());
-                        }
-                        overflow = false
-                    }
-
-                    if overflow {
-                        // Create a span with the same properties and add it to the line.
-                        println!("LINEBREAK: Overflow encountered", );
-
-                        let span = TextSpan {
-                            text: line_segment_chars_to_add.clone(),
-                            is_bold: span.is_bold,
-                            is_italic: span.is_italic,
-                            is_ruby_base: span.is_ruby_base,
-                            ruby_text: span.ruby_text.clone(),
-                            new_text_block: false,
-                        };
-                        current_line_spans.push(span);
-                        println!("Adding current line spans to lines: {:?}", current_line_spans);
-
-                        lines.push(current_line_spans);
-                        current_line_spans = Vec::new();
-                        current_line_width = 0;
-                        overflow = false
-                    }
-                }
-
-                remaining_text_in_span = remaining_text_in_span.chars().skip(chars_consumed_from_remaining).collect();
-
-                if remaining_text_in_span.is_empty() {
-                    println!("No text left in span", );
-
-                    // The new line may or may not start a newline, but we aren't sure yet.  
-                    let span = TextSpan {
-                        text: line_segment_chars_to_add.clone(),
-                        is_bold: span.is_bold,
-                        is_italic: span.is_italic,
-                        is_ruby_base: span.is_ruby_base,
-                        ruby_text: span.ruby_text.clone(),
-                        new_text_block: false,
-                    };
-
-                    current_line_spans.push(span);
-                    println!("Appending Span to current line spans: {:?}", current_line_spans);
-                    current_line_width += current_segment_width_temp; // Use the accumulated width for efficiency
-                }
-
-            }
-
-            // End the previously line and start a new one if we have a new text block span.
-            if span.new_text_block {
+                // Finalize the current line and start fresh.
                 lines.push(current_line_spans);
                 current_line_spans = Vec::new();
                 current_line_width = 0;
             }
-
         }
 
+        // Add the very last line.
         if !current_line_spans.is_empty() {
-            lines.push(current_line_spans); // Always add the last line even if empty.
+            lines.push(current_line_spans);
         }
-
-        
-        // Final check: if no lines were formed at all, ensure there's at least one empty line.
         if lines.is_empty() {
             lines.push(Vec::new());
         }
 
         let total_height = line_height * lines.len() as i32;
-        println!("{:?} Lines", lines);
-
-        Ok(TextLayout {
-            lines,
-            total_height,
-            scroll_offset: 0,
-        })
+        Ok(TextLayout { lines, total_height, scroll_offset: 0 })
     }
+
+
+    // /// Calculates how to wrap text and returns a layout object.
+    // /// This processes TextSpans, handles explicit newlines, and implements
+    // /// character-by-character wrapping to ensure content fits within max_width
+    // pub fn layout_text(&mut self, spans: &[TextSpan], max_width: u32) -> Result<TextLayout, String> {
+    //     let mut lines: Vec<Vec<TextSpan>> = Vec::new();
+    //     let mut current_line_spans: Vec<TextSpan> = Vec::new();
+    //     let mut current_line_width = 0;
+    //     let line_height = self.font.height();
+    //     let mut overflow = false;
+
+    //     // Ensure at least one line to start with if spans are empty or to handle leading newlines
+    //     if spans.is_empty() {
+    //         lines.push(Vec::new());
+    //         return Ok(TextLayout { lines, total_height: line_height as i32, scroll_offset: 0 });
+    //     }
+
+    //     for span in spans {
+
+    //         // Get the text from the span. We will add it step-by-step to the current list of spans in this line.
+    //         // If the line gets too long, we will split this span into two and add the current "line spans" to the line array.
+
+    //         if span.new_text_block {
+    //             if !current_line_spans.is_empty() {
+    //                 lines.push(current_line_spans);
+    //                 current_line_spans = Vec::new();
+    //                 current_line_width = 0;
+    //             }
+    //         }
+
+
+    //         let mut remaining_text_in_span: String = span.text.clone().trim().to_string();
+
+    //         // Loop while there's text left in the current span to process
+    //         while !remaining_text_in_span.is_empty() {
+    //             let mut line_segment_chars_to_add = String::new(); // Reset the chars to add to the line from the current span.
+    //             let mut chars_consumed_from_remaining = 0; // Chars in remaining_text_in_span that were processed for this line
+    //             let mut current_segment_width_temp = 0; // Width of `line_segment_chars_to_add`
+    //             let mut hard_break_encountered = false;
+
+    //             // Iterate through characters of the remaining span text to build a line segment, until we run out of characters or space.
+    //             for char_c in remaining_text_in_span.chars() {
+    //                 if char_c == '\n' {
+    //                     // Found a hard newline character, break the line here
+    //                     hard_break_encountered = true;
+    //                     chars_consumed_from_remaining += 1; // Consume the newline char
+    //                     break; // Stop accumulating chars for this line segment
+    //                 }
+
+    //                 let (char_width, _) = self.size_of_text_with_style(
+    //                     &char_c.to_string(),
+    //                     span.is_bold, // Use original span's style for width calculation
+    //                     span.is_italic
+    //                 )?;
+
+    //                 let potential_line_width = current_line_width + current_segment_width_temp + char_width;
+    //                 if potential_line_width <= max_width {
+    //                     line_segment_chars_to_add.push(char_c);
+    //                     current_segment_width_temp += char_width;
+    //                     chars_consumed_from_remaining += 1; // Count char taken from remaining_text_in_span
+
+    //                     // println!("Characters to add; {:?}", line_segment_chars_to_add);
+    //                 } else {
+    //                     // Overflow.  Perform line processing and then return to the remaining characters via the for loop.
+    //                     overflow = true;
+    //                     break;
+    //                 }
+    //             }
+
+    //             // println!("{:?}", line_segment_chars_to_add);
+    //             // println!("{:?}", chars_consumed_from_remaining);
+    //             // println!("{:?}", current_segment_width_temp);
+    //             // println!("{:?}", hard_break_encountered);
+
+    //             // This happens when a hard break (\n) is encountered, or a character is encountered, or we run out of characters in this current span.
+
+    //             let requires_newline = hard_break_encountered || overflow;
+
+    //             if requires_newline {
+    //                 if hard_break_encountered {
+    //                     // println!("LINEBREAK: Hard Break encountered", );
+    //                     if !line_segment_chars_to_add.is_empty() {
+    //                         let span = TextSpan {
+    //                             text: line_segment_chars_to_add.clone(),
+    //                             is_bold: span.is_bold,
+    //                             is_italic: span.is_italic,
+    //                             is_ruby_base: span.is_ruby_base,
+    //                             ruby_text: span.ruby_text.clone(),
+    //                             new_text_block: false,
+    //                             is_newline: true,
+    //                         };
+    //                         // println!("{:?}", span);
+    //                         current_line_spans.push(span);
+    //                         current_line_width += current_segment_width_temp; // Use the accumulated width for efficiency
+    //                     }
+    //                     if !current_line_spans.is_empty() {
+    //                         lines.push(current_line_spans);
+    //                         current_line_spans = Vec::new();
+    //                         current_line_width = 0;
+    //                     } else {
+    //                         lines.push(Vec::new());
+    //                     }
+    //                     overflow = false
+    //                 }
+
+    //                 if overflow {
+    //                     // Create a span with the same properties and add it to the line.
+    //                     // println!("LINEBREAK: Overflow encountered", );
+
+    //                     let span = TextSpan {
+    //                         text: line_segment_chars_to_add.clone(),
+    //                         is_bold: span.is_bold,
+    //                         is_italic: span.is_italic,
+    //                         is_ruby_base: span.is_ruby_base,
+    //                         ruby_text: span.ruby_text.clone(),
+    //                         new_text_block: false,
+    //                         is_newline: false,
+    //                     };
+    //                     current_line_spans.push(span);
+    //                     // println!("Adding current line spans to lines: {:?}", current_line_spans);
+
+    //                     lines.push(current_line_spans);
+    //                     current_line_spans = Vec::new();
+    //                     current_line_width = 0;
+    //                     overflow = false
+    //                 }
+    //             }
+
+    //             remaining_text_in_span = remaining_text_in_span.chars().skip(chars_consumed_from_remaining).collect();
+
+    //             if remaining_text_in_span.is_empty() {
+    //                 // println!("No text left in span", );
+
+    //                 // The new line may or may not start a newline, but we aren't sure yet.  
+    //                 let span = TextSpan {
+    //                     text: line_segment_chars_to_add.clone(),
+    //                     is_bold: span.is_bold,
+    //                     is_italic: span.is_italic,
+    //                     is_ruby_base: span.is_ruby_base,
+    //                     ruby_text: span.ruby_text.clone(),
+    //                     new_text_block: false,
+    //                     is_newline: false,
+    //                 };
+
+    //                 current_line_spans.push(span);
+    //                 // println!("Appending Span to current line spans: {:?}", current_line_spans);
+    //                 current_line_width += current_segment_width_temp; // Use the accumulated width for efficiency
+    //             }
+
+    //         }
+
+    //         // End the previously line and start a new one if we have a new text block span.
+    //         if span.new_text_block {
+    //             lines.push(current_line_spans);
+    //             current_line_spans = Vec::new();
+    //             current_line_width = 0;
+    //         }
+
+    //     }
+
+    //     if !current_line_spans.is_empty() {
+    //         lines.push(current_line_spans); // Always add the last line even if empty.
+    //     }
+
+        
+    //     // Final check: if no lines were formed at all, ensure there's at least one empty line.
+    //     if lines.is_empty() {
+    //         lines.push(Vec::new());
+    //     }
+
+    //     let total_height = line_height * lines.len() as i32;
+    //     // println!("{:?} Lines", lines);
+
+    //     Ok(TextLayout {
+    //         lines,
+    //         total_height,
+    //         scroll_offset: 0,
+    //     })
+    // }
 
     /// Renders a pre-calculated TextLayout to the screen.
     pub fn draw_layout(&mut self, canvas: &mut Canvas<Window>, layout: &TextLayout, x: i32, y: i32) -> Result<(), String> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,12 +1,10 @@
 // src/ui/mod.rs
 // This module contains all components related to the User Interface.
 
-// We declare the canvas, font, and sprite modules.
-pub mod canvas;
-pub mod font;
-pub mod sprite; // Make the sprite module public
+pub mod canvas; // For upscaling our view
+pub mod font;   // For text 
+pub mod sprite; // For cute sprites (not yet implemented)
 
-// We can re-export the main structs here for easier access from other parts of the app.
 pub use self::canvas::CanvasManager;
 pub use self::font::FontManager;
-pub use self::sprite::Sprite; // Re-export the Sprite struct
+pub use self::sprite::Sprite;


### PR DESCRIPTION
- The initial version of the code for generating spans was incomprehensible.  I made a separate version and then had Gemini propose some alternatives that I integrated.

- Some special modifications to allow Ruby/rb/rt to be correctly displayed.  I have setup a toggle button to switch views.

- There is a python tool to help fix some of the HTML formatting in flashcard files.