### PR TITLE
Evolve cardbrick-py into a CardBrick-style Spanish study appliance

### DIFF
--- a/cardbrick-py/README.md
+++ b/cardbrick-py/README.md
@@ -1,18 +1,17 @@
 # CardBrick-Py
 
-A proof-of-concept flashcard reviewer for inexpensive ARM Linux handhelds
-(RG35XX SP running Knulli, TrimUI Brick, and similar), written in pure
-Python with pygame.
+A CardBrick-style **Spanish study appliance** for inexpensive ARM Linux
+handhelds (RG35XX SP running Knulli, TrimUI Brick, and similar), written
+in pure Python with pygame.
 
-This is a deliberate pivot from the original Rust implementation in the
-parent directory. Native compilation made deployment across the zoo of
-cheap handhelds difficult; this prototype trades raw performance for
-portability: **if the device can run Python and pygame, it can run
-CardBrick-Py.**
+The target experience is a Game Boy-style educational cartridge, not a
+desktop app: a child turns the handheld on, opens the app, reviews a
+small capped number of cards with audio, sees a completion screen, and
+is done. Parents configure everything else in a separate parent mode.
 
-The objective is *not* to recreate Anki. Anki's `.apkg` files are used as
-a **content format only** — after a one-time import, the application runs
-entirely from its own SQLite database with no Anki desktop, no
+The objective is *not* to recreate Anki. Anki's `.apkg` files are used
+as a **content format only** — after a one-time import, the application
+runs entirely from its own SQLite database with no Anki desktop, no
 AnkiConnect, no Rust backend, and no network access.
 
 ## Architecture
@@ -22,17 +21,23 @@ AnkiConnect, no Rust backend, and no network access.
   ↓
 Importer          (cardbrick/importer.py — zipfile + sqlite3, reads the
   ↓                archive directly, no Anki code)
-Local SQLite DB   (cardbrick/storage.py — cards + review_state tables)
-  ↓
+Local SQLite DB   (cardbrick/storage.py — cards, review_state, an
+  ↓                append-only review_log, sessions, child_profiles)
 FSRS scheduler    (cardbrick/scheduler.py — thin wrapper around py-fsrs;
   ↓                the algorithm itself is NOT reimplemented)
-Pygame reviewer   (cardbrick/ui.py — 640x480, controller-friendly)
+Review service    (cardbrick/service.py — daily limits, category
+  ↓                filtering, undo, bury/suspend; injectable clock)
+Session runner    (cardbrick/session.py — one sitting: queue, counters,
+  ↓                summary)
+Pygame app        (cardbrick/app.py — state-driven child/parent UI on a
+                   640x480 logical canvas, controller-first)
 ```
 
-Supporting modules: `cardbrick/audio.py` (pygame.mixer playback of
-`[sound:...]` references, fails soft without an audio device) and
-`cardbrick/textutil.py` (HTML stripping, audio-tag extraction, pixel
-word-wrapping with per-character fallback for CJK text).
+Supporting modules: `cardbrick/audio.py` ([sound:...] playback, fails
+soft without an audio device), `cardbrick/settings.py` (JSON app
+settings), `cardbrick/textutil.py` (HTML stripping, wrapping), and
+`cardbrick/ui.py` (the original minimal prototype reviewer, kept
+working under `python main.py review`).
 
 ### Dependencies
 
@@ -43,11 +48,103 @@ Only two, both pure-Python-installable on ARM:
 | `pygame` | display, input, audio                     |
 | `fsrs`   | py-fsrs, the FSRS spaced-repetition engine |
 
-Everything else is the standard library (`sqlite3`, `zipfile`, `json`,
-`html`). No Rust, no compilation beyond what pygame's prebuilt wheels
-provide, no private Anki APIs.
+Everything else is the standard library. No Rust, no compilation beyond
+what pygame's prebuilt wheels provide, no private Anki APIs.
 
-### The importer
+## Usage
+
+```bash
+pip install -r requirements.txt
+
+# One-time import (repeatable; progress is preserved). Also available
+# inside the app's parent mode.
+python main.py import MyDeck.apkg
+
+# The study appliance (child/parent flow) — this is the default command
+python main.py study                  # add --fullscreen on the handheld
+
+# Configure the child profile from the command line (parent mode can do
+# the same on-device)
+python main.py profile --name Maya --daily-new 10 --daily-review 40 \
+    --session-cards 50 --session-minutes 15 --categories restaurant,food
+python main.py profile --categories all      # study every tag
+
+# Legacy prototype reviewer (no limits/undo/profiles)
+python main.py review [--deck NAME] [--fullscreen]
+python main.py decks                  # list decks + due counts
+```
+
+No deck handy? Generate a test one:
+`python scripts/make_sample_apkg.py sample.apkg`
+
+Data lives in `./data/` next to `main.py` (override with `--data-dir`
+or the `CARDBRICK_DATA` env var): `cardbrick.db` (SQLite),
+`settings.json` (app settings, hand-editable), and `media/`. The whole
+application plus its data is a single copyable folder.
+
+## The daily loop
+
+```
+SPANISH PRACTICE
+      Maya
+restaurant, food
+ 12 cards today                Front: ¿Dónde está el baño?  ♪
+ 8 to review + 4 new     -->   D-pad = show answer          -->  ¡Buen trabajo!
+Press A to start!              B=Again Y=Hard A=Good X=Easy      session stats
+                               R=Bury  SELECT=Menu
+```
+
+### Controls (study)
+
+| Input   | Question side       | Answer side |
+|---------|---------------------|-------------|
+| D-pad   | Reveal answer       | —           |
+| A       | Reveal answer       | Good        |
+| B       | —                   | Again       |
+| X       | —                   | Easy        |
+| Y       | —                   | Hard        |
+| L       | Replay audio        | Replay audio|
+| R       | —                   | Bury until tomorrow |
+| SELECT  | Action menu (undo / bury / suspend / end) | same |
+| START   | Finish session      | same        |
+
+Keyboard fallback for desktop testing: arrows/Space reveal, `1/2/3/4` =
+Again/Hard/Good/Easy (or literal `A/B/X/Y` keys), `L` replay, `R` bury,
+`U` undo, `Tab` menu, `Esc` finish.
+
+Gamepad button numbering differs between handhelds; remap without
+touching code via
+`CARDBRICK_JOYMAP="A=1,B=0,X=3,Y=2,L=4,R=5,SELECT=6,START=7"`.
+A font override is available the same way:
+`CARDBRICK_FONT=/path/to/font.ttf`.
+
+### Parent mode
+
+`SELECT` on the start screen. From there: import `.apkg` files found in
+the data folder (or `data/import/`, or the app folder), choose active
+categories (Anki tags) for the child, set daily limits, review/restore
+suspended cards, see a 7-day progress table, and flip the study
+direction (front-first / back-first). There is no PIN yet — the flows
+are separated, not locked.
+
+### Daily limits
+
+Per child profile: `daily_new_cards` (default 10), `daily_review_cards`
+(40), `session_card_limit` (50), `session_time_minutes` (15, 0 = off).
+Limits count work already done today across restarts (derived from the
+review log), reviews are queued before new cards, and a backlog never
+floods the child — extra due cards simply wait for tomorrow.
+
+### Durability
+
+Every answer is committed to SQLite before the next card appears, with
+the prior FSRS state snapshotted into an append-only `review_log` in the
+same transaction — undo is an exact restore, and a crash or power-off
+never loses a completed review. Sessions left open by a crash are closed
+on the next boot. The schema migrates in place from the original
+prototype database.
+
+## The importer
 
 `.apkg` is a zip archive containing an SQLite collection plus numbered
 media files. The importer:
@@ -56,7 +153,8 @@ media files. The importer:
    `notes`, `cards`, and `col` tables directly.
 2. Reduces each card to a **front/back pair** from the note's first two
    fields, honouring the card ordinal — so *Basic (and reversed card)*
-   notes yield both directions. Cloze note types are skipped.
+   notes yield both directions. Cloze note types are skipped, with
+   skip reasons reported.
 3. Strips HTML down to plain text and pulls out `[sound:file]`
    references into an `audio_filename` + `audio_side` column.
 4. Copies media into `data/media/` under their real names, using the
@@ -69,75 +167,17 @@ supported (it would need a native zstd + protobuf dependency). Anki
 desktop exports the legacy format when *"Support older Anki versions"*
 is checked.
 
-### The database
-
-`data/cardbrick.db`, two tables:
-
-- **cards** — `id, note_id, deck, front, back, tags, audio_filename,
-  audio_side`
-- **review_state** — `card_id, due, stability, difficulty, elapsed_days,
-  scheduled_days, reps, lapses, state, fsrs_json`
-
-`fsrs_json` holds the py-fsrs card serialization verbatim
-(`Card.to_dict()`), so scheduling state round-trips losslessly through
-the library; the flat columns exist for querying and inspection. All
-timestamps are UTC ISO-8601 strings, which compare correctly as text in
-SQL.
-
-### The scheduler
-
-`ReviewScheduler` delegates every scheduling decision to
-`fsrs.Scheduler.review_card()`. The wrapper only converts between stored
-rows and `fsrs.Card` objects and maintains the `reps`/`lapses` counters.
-Learning steps are py-fsrs defaults (1 min, 10 min), so freshly-rated
-cards come back within the same session; when nothing is due the UI
-shows an "all caught up" screen that automatically resumes when the next
-learning-step card matures.
-
-## Usage
+## Tests
 
 ```bash
-pip install -r requirements.txt
-
-# One-time import (repeatable; progress is preserved)
-python main.py import MyDeck.apkg
-
-# Review
-python main.py review                 # deck picker if multiple decks
-python main.py review --deck Spanish --fullscreen
-python main.py decks                  # list decks + due counts
+pip install pytest
+python -m pytest tests/
 ```
 
-No deck handy? Generate a test one:
-`python scripts/make_sample_apkg.py sample.apkg`
-
-Data lives in `./data/` next to `main.py` (override with `--data-dir`
-or the `CARDBRICK_DATA` env var) — the whole application plus its data
-is a single copyable folder, which is exactly what handheld "ports"
-launchers want.
-
-## Controls
-
-```
-------------------------------------
-Deck: Spanish
-¿Dónde está el baño?
-------------------------------------
-Any button = Show answer
-A = Again    B = Hard
-X = Good     Y = Easy
-Start = Exit
-```
-
-Keyboard fallback for desktop testing: `A/B/X/Y` or `1/2/3/4` to rate,
-`Space`/`Enter` to flip, `Esc` to exit, arrows to navigate the deck menu.
-
-Gamepad button numbering differs between handhelds; remap without
-touching code via
-`CARDBRICK_JOYMAP="A=1,B=0,X=3,Y=2,START=7,SELECT=6"`.
-A font override is available the same way: `CARDBRICK_FONT=/path/to/font.ttf`
-(drop a Noto CJK font there for Japanese decks; the repo's
-`assets/font/NotoSansCJK-Regular.ttc` works).
+Covers daily limits (including backlog protection and midnight
+rollover), exact undo, bury/suspend, tag filtering, the importer, and
+crash/restart persistence — all with an injected deterministic clock,
+temp directories, and no pygame.
 
 ## Deploying to a handheld
 
@@ -148,13 +188,14 @@ A font override is available the same way: `CARDBRICK_FONT=/path/to/font.ttf`
    and launch with `PYTHONPATH=vendor`. (Knulli and most Batocera-derived
    firmwares already ship Python; many also ship pygame.)
 3. Add a Ports-style launcher script that runs
-   `python3 main.py review --fullscreen`.
-4. Import decks on your PC and copy the `data/` folder over, or run the
-   import on-device — either works, it's the same folder.
+   `python3 main.py study --fullscreen`.
+4. Import decks on your PC and copy the `data/` folder over, or drop the
+   `.apkg` in `data/` and import from parent mode on-device.
 
 ## Scope (deliberately excluded)
 
-No sync, no editing, no statistics, no HTML rendering beyond tag
-stripping, no card templates, no cloze, no image occlusion, no images at
-all. This is a prototype proving the pipeline:
+No sync, no cloze, no image occlusion, no images at all, no HTML
+rendering beyond tag stripping, no card templates, no `.apkg` export, no
+TTS (the audio layer is structured so it can be added later), no
+gamification. This is a focused daily study appliance:
 **apkg → local DB → py-fsrs → pygame**.

--- a/cardbrick-py/cardbrick/app.py
+++ b/cardbrick-py/cardbrick/app.py
@@ -1,0 +1,796 @@
+"""CardBrick-style study appliance UI.
+
+A state-driven pygame app aimed at children doing a short daily Spanish
+session on a handheld. Screens:
+
+    ChildStart -> Review (question/answer) -> SessionSummary -> ChildStart
+    ChildStart -> ParentMode (import / categories / limits / suspended /
+                              progress) -> ChildStart
+
+Controller-first. Default roles (per the product spec):
+
+    D-pad          reveal answer
+    A              Good        B  Again
+    X              Easy        Y  Hard
+    L              replay audio
+    R              bury until tomorrow
+    SELECT         action menu / parent mode
+    START          finish session / back
+
+Keyboard fallback for desktop testing: arrows reveal, 1/2/3/4 =
+Again/Hard/Good/Easy (or literal A/B/X/Y keys), L replay, R bury,
+U undo, Tab menu, Esc finish.
+
+Everything renders on a fixed logical canvas (default 640x480, the
+RG35XX SP panel); pygame.SCALED stretches it to whatever display the
+device has.
+"""
+
+import os
+
+import pygame
+
+from .importer import ApkgError, import_apkg
+from .scheduler import iso
+from .session import StudySession
+from .textutil import wrap_text
+
+FPS = 30
+
+BG = (24, 26, 30)
+FG = (235, 235, 228)
+DIM = (140, 142, 148)
+ACCENT = (120, 180, 250)
+GOOD = (120, 210, 140)
+WARN = (240, 180, 100)
+BAD = (235, 120, 120)
+DIVIDER = (70, 72, 78)
+OVERLAY_BG = (36, 39, 45)
+
+# Physical gamepad button numbers vary between handhelds; remap without
+# touching code via CARDBRICK_JOYMAP="A=1,B=0,X=3,Y=2,L=4,R=5,SELECT=6,START=7"
+DEFAULT_JOYMAP = {0: "A", 1: "B", 2: "X", 3: "Y", 4: "L", 5: "R",
+                  6: "SELECT", 7: "START"}
+
+# Button role -> FSRS rating (spec: A=Good, B=Again, X=Easy, Y=Hard).
+RATING_FOR_BUTTON = {"B": 1, "Y": 2, "A": 3, "X": 4}
+
+KEYBOARD_MAP = {
+    pygame.K_UP: "UP", pygame.K_DOWN: "DOWN",
+    pygame.K_LEFT: "LEFT", pygame.K_RIGHT: "RIGHT",
+    pygame.K_RETURN: "A", pygame.K_SPACE: "A",
+    pygame.K_a: "A", pygame.K_b: "B",
+    pygame.K_x: "X", pygame.K_y: "Y",
+    pygame.K_1: "B", pygame.K_2: "Y",     # 1=Again 2=Hard
+    pygame.K_3: "A", pygame.K_4: "X",     # 3=Good  4=Easy
+    pygame.K_l: "L", pygame.K_r: "R",
+    pygame.K_u: "UNDO",
+    pygame.K_TAB: "SELECT",
+    pygame.K_ESCAPE: "START", pygame.K_q: "START",
+}
+
+DPAD = ("UP", "DOWN", "LEFT", "RIGHT")
+
+FONT_CANDIDATES = [
+    os.environ.get("CARDBRICK_FONT", ""),
+    os.path.join(os.path.dirname(__file__), "..", "assets", "fonts",
+                 "main.ttf"),
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+]
+
+
+def _load_font(size):
+    for path in FONT_CANDIDATES:
+        if path and os.path.exists(path):
+            try:
+                return pygame.font.Font(path, size)
+            except pygame.error:
+                continue
+    return pygame.font.Font(None, size + 6)  # pygame default runs small
+
+
+def _parse_joymap():
+    raw = os.environ.get("CARDBRICK_JOYMAP")
+    if not raw:
+        return dict(DEFAULT_JOYMAP)
+    joymap = {}
+    for pair in raw.split(","):
+        name, _, num = pair.strip().partition("=")
+        if num.isdigit():
+            joymap[int(num)] = name.strip().upper()
+    return joymap or dict(DEFAULT_JOYMAP)
+
+
+class QuitApp(Exception):
+    """Raised when the window is closed; unwinds any screen loop."""
+
+
+class CardBrickApp:
+    def __init__(self, storage, service, audio, settings, fullscreen=None):
+        self.storage = storage
+        self.service = service
+        self.audio = audio
+        self.settings = settings
+        self.joymap = _parse_joymap()
+
+        pygame.init()
+        width = int(settings.get("logical_width", 640))
+        height = int(settings.get("logical_height", 480))
+        self.w, self.h = width, height
+        if fullscreen is None:
+            fullscreen = bool(settings.get("fullscreen"))
+        flags = pygame.SCALED | (pygame.FULLSCREEN if fullscreen else 0)
+        self.screen = pygame.display.set_mode((width, height), flags)
+        pygame.display.set_caption("CardBrick — Spanish Practice")
+        pygame.mouse.set_visible(False)
+        for i in range(pygame.joystick.get_count()):
+            pygame.joystick.Joystick(i).init()
+
+        self.font_big = _load_font(38)
+        self.font = _load_font(26)
+        self.font_small = _load_font(18)
+        self.clock = pygame.time.Clock()
+
+        # Crash recovery: close sessions that never got an end stamp.
+        self.storage.close_dangling_sessions(iso(self.service.now()))
+        self.profile = self._boot_profile()
+
+    def _boot_profile(self):
+        profile_id = self.settings.get("current_child_profile_id")
+        profile = self.storage.get_profile(profile_id) if profile_id else None
+        if profile is None:
+            profile = self.storage.ensure_default_profile()
+            self.settings.set("current_child_profile_id", profile["id"])
+        return profile
+
+    def _reload_profile(self):
+        self.profile = self.storage.get_profile(self.profile["id"])
+
+    # -- main state machine ------------------------------------------------------
+
+    def run(self):
+        state = "CHILD_START"
+        handlers = {
+            "CHILD_START": self.screen_child_start,
+            "REVIEW": self.screen_review,
+            "SUMMARY": self.screen_summary,
+            "PARENT_MENU": self.screen_parent_menu,
+            "PARENT_IMPORT": self.screen_parent_import,
+            "PARENT_CATEGORIES": self.screen_parent_categories,
+            "PARENT_LIMITS": self.screen_parent_limits,
+            "PARENT_SUSPENDED": self.screen_parent_suspended,
+            "PARENT_PROGRESS": self.screen_parent_progress,
+        }
+        try:
+            while state != "QUIT":
+                state = handlers[state]()
+        except QuitApp:
+            pass
+        finally:
+            pygame.quit()
+
+    # -- input ---------------------------------------------------------------------
+
+    def poll(self):
+        """Next logical button press, or None.
+
+        Consumes exactly one meaningful event per call so rapid inputs
+        queued between frames are never dropped.
+        """
+        while True:
+            event = pygame.event.poll()
+            if event.type == pygame.NOEVENT:
+                return None
+            if event.type == pygame.QUIT:
+                raise QuitApp
+            if event.type == pygame.KEYDOWN:
+                action = KEYBOARD_MAP.get(event.key)
+                if action:
+                    return action
+            elif event.type == pygame.JOYBUTTONDOWN:
+                return self.joymap.get(event.button, "OTHER")
+            elif event.type == pygame.JOYHATMOTION:
+                x, y = event.value
+                if y == 1:
+                    return "UP"
+                if y == -1:
+                    return "DOWN"
+                if x == -1:
+                    return "LEFT"
+                if x == 1:
+                    return "RIGHT"
+
+    # -- child start -----------------------------------------------------------------
+
+    def screen_child_start(self):
+        review_n, new_n = self.service.counts_for_queue(profile=self.profile)
+        total = review_n + new_n
+        categories = self.profile["active_categories"]
+        cat_label = "All categories" if categories is None else \
+            ", ".join(categories) if categories else "No categories!"
+
+        while True:
+            action = self.poll()
+            if action == "START":
+                return "QUIT"
+            if action == "SELECT":
+                return "PARENT_MENU"
+            if action in ("A", "OTHER") and total > 0:
+                return "REVIEW"
+
+            self.screen.fill(BG)
+            self._center(self.font_small.render("SPANISH PRACTICE", True,
+                                                DIM), 36)
+            self._center(self.font_big.render(self.profile["name"], True,
+                                              FG), 80)
+            self._center(self.font.render(cat_label, True, ACCENT), 150)
+            if total > 0:
+                due_text = f"{total} cards today"
+                detail = f"{review_n} to review  +  {new_n} new"
+                self._center(self.font_big.render(due_text, True, FG), 215)
+                self._center(self.font.render(detail, True, DIM), 265)
+                limit_line = (f"up to {self.profile['session_card_limit']} "
+                              f"cards / "
+                              f"{self.profile['session_time_minutes']} min")
+                self._center(self.font_small.render(limit_line, True, DIM),
+                             305)
+                self._center(self.font.render("Press A to start!", True,
+                                              GOOD), 360)
+            else:
+                self._center(self.font_big.render("All done for today!",
+                                                  True, GOOD), 230)
+                self._center(self.font.render("Come back tomorrow.", True,
+                                              DIM), 285)
+            self._footer("A = Start   SELECT = Parent mode   START = Quit"
+                         if total else
+                         "SELECT = Parent mode   START = Quit")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    # -- review ----------------------------------------------------------------------
+
+    MENU_ENTRIES = ("Undo last answer", "Bury card (back tomorrow)",
+                    "Suspend card (parent will check)", "End session",
+                    "Cancel")
+
+    def screen_review(self):
+        session = StudySession(self.storage, self.service, self.profile)
+        reversed_mode = self.profile.get("study_direction") == "reversed"
+        auto_play = bool(self.settings.get("auto_play_audio", True))
+
+        flipped = False
+        shown_at = None
+        audio_status = None
+        menu = None  # action-menu overlay index, or None when closed
+
+        def audio_for(card, side):
+            """Audio filename if the card's audio belongs on this side
+            of the *displayed* card (side: 'front'|'back')."""
+            if not card["audio_filename"]:
+                return None
+            actual = card["audio_side"]
+            if reversed_mode and actual in ("front", "back"):
+                actual = "back" if actual == "front" else "front"
+            return card["audio_filename"] if actual == side else None
+
+        def play(card, side, forced=False):
+            nonlocal audio_status
+            filename = audio_for(card, side) or (
+                card["audio_filename"] if forced else None)
+            if not filename:
+                return
+            audio_status = "playing" if self.audio.play(filename) \
+                else "missing"
+
+        def begin_card(card):
+            nonlocal flipped, shown_at, audio_status
+            flipped = False
+            shown_at = self.service.now()
+            audio_status = None
+            if card["audio_filename"] and not self.audio.available(
+                    card["audio_filename"]):
+                audio_status = "missing"
+            if auto_play:
+                play(card, "front")
+
+        def advance():
+            """Fetch the next card after the current one was consumed.
+
+            The optional time limit is checked here, between cards, so
+            a child is never cut off while thinking about an answer.
+            """
+            nonlocal card
+            self.audio.stop()
+            card = None if session.time_limit_reached() \
+                else session.current_card()
+            if card:
+                begin_card(card)
+
+        def end_session():
+            self.audio.stop()
+            session.finish()
+            self._summary = session.summary()
+            return "SUMMARY"
+
+        card = session.current_card()
+        if card:
+            begin_card(card)
+
+        while True:
+            if card is None:
+                return end_session()
+
+            action = self.poll()
+            if menu is not None:
+                if action == "UP":
+                    menu = (menu - 1) % len(self.MENU_ENTRIES)
+                elif action == "DOWN":
+                    menu = (menu + 1) % len(self.MENU_ENTRIES)
+                elif action in ("B", "SELECT", "START"):
+                    menu = None
+                elif action == "A":
+                    choice, menu = self.MENU_ENTRIES[menu], None
+                    if choice.startswith("Undo"):
+                        restored = session.undo()
+                        if restored is not None:
+                            card = restored
+                            begin_card(card)
+                    elif choice.startswith("Bury"):
+                        session.bury_current()
+                        advance()
+                    elif choice.startswith("Suspend"):
+                        session.suspend_current()
+                        advance()
+                    elif choice == "End session":
+                        return end_session()
+            elif action == "START":
+                return end_session()
+            elif action == "SELECT":
+                menu = 0
+            elif action == "L":
+                play(card, "back" if flipped else "front", forced=True)
+            elif action == "UNDO":
+                restored = session.undo()
+                if restored is not None:
+                    card = restored
+                    begin_card(card)
+            elif not flipped:
+                if action in DPAD or action in ("A", "OTHER"):
+                    flipped = True
+                    if auto_play:
+                        play(card, "back")
+            elif action in RATING_FOR_BUTTON:
+                elapsed = int((self.service.now() -
+                               shown_at).total_seconds() * 1000)
+                session.answer(RATING_FOR_BUTTON[action], elapsed_ms=elapsed)
+                advance()
+                continue
+            elif action == "R":
+                session.bury_current()
+                advance()
+                continue
+
+            self._draw_review(session, card, flipped, audio_status, menu)
+            self.clock.tick(FPS)
+
+    def _draw_review(self, session, card, flipped, audio_status, menu):
+        self.screen.fill(BG)
+        reversed_mode = self.profile.get("study_direction") == "reversed"
+        front, back = (card["back"], card["front"]) if reversed_mode \
+            else (card["front"], card["back"])
+
+        header = card["deck"]
+        if card["tags"]:
+            header += "  ·  " + " ".join(card["tags"].split()[:3])
+        self.screen.blit(self.font_small.render(header, True, DIM), (16, 12))
+        left = f"{session.remaining()} left"
+        surf = self.font_small.render(left, True, DIM)
+        self.screen.blit(surf, (self.w - surf.get_width() - 16, 12))
+        pygame.draw.line(self.screen, DIVIDER, (16, 40), (self.w - 16, 40))
+
+        margin = 36
+        max_width = self.w - 2 * margin
+        y = self._block(front, self.font_big, FG, top=64,
+                        max_width=max_width)
+
+        if audio_status == "missing":
+            self._center(self.font_small.render("(no audio)", True, WARN),
+                         y + 6)
+        elif card["audio_filename"]:
+            self._center(self.font_small.render("♪  L = replay", True, DIM),
+                         y + 6)
+
+        if flipped:
+            div_y = max(y + 34, 210)
+            pygame.draw.line(self.screen, DIVIDER, (margin, div_y),
+                             (self.w - margin, div_y))
+            self._block(back, self.font, ACCENT, top=div_y + 18,
+                        max_width=max_width)
+            self._footer("B=Again  Y=Hard  A=Good  X=Easy   "
+                         "R=Bury  SELECT=Menu  START=Finish")
+        else:
+            self._footer("D-pad = Show answer   L = Replay audio   "
+                         "START = Finish")
+
+        if menu is not None:
+            self._draw_menu_overlay(menu)
+        pygame.display.flip()
+
+    def _draw_menu_overlay(self, index):
+        entries = self.MENU_ENTRIES
+        box_w, line_h = 440, 42
+        box_h = line_h * len(entries) + 32
+        x = (self.w - box_w) // 2
+        y = (self.h - box_h) // 2
+        pygame.draw.rect(self.screen, OVERLAY_BG, (x, y, box_w, box_h),
+                         border_radius=8)
+        pygame.draw.rect(self.screen, DIVIDER, (x, y, box_w, box_h), 2,
+                         border_radius=8)
+        for i, entry in enumerate(entries):
+            color = ACCENT if i == index else FG
+            prefix = "> " if i == index else "   "
+            surf = self.font.render(prefix + entry, True, color)
+            self.screen.blit(surf, (x + 24, y + 16 + i * line_h))
+
+    # -- summary ---------------------------------------------------------------------
+
+    def screen_summary(self):
+        s = getattr(self, "_summary", None) or {}
+        minutes = int(s.get("time_spent_seconds", 0) // 60)
+        seconds = int(s.get("time_spent_seconds", 0) % 60)
+        pass_rate = s.get("pass_rate")
+        avg = s.get("avg_response_ms")
+
+        lines = [
+            (f"Cards answered:  {s.get('cards_reviewed', 0)}", FG),
+            (f"New cards:  {s.get('new_cards', 0)}    "
+             f"Reviews:  {s.get('review_cards', 0)}", FG),
+            (f"Again {s.get('again_count', 0)}   "
+             f"Hard {s.get('hard_count', 0)}   "
+             f"Good {s.get('good_count', 0)}   "
+             f"Easy {s.get('easy_count', 0)}", DIM),
+            (f"Pass rate:  {pass_rate:.0%}" if pass_rate is not None
+             else "Pass rate:  —", DIM),
+            (f"Time:  {minutes}m {seconds:02d}s" +
+             (f"    Avg answer:  {avg / 1000:.1f}s" if avg else ""), DIM),
+        ]
+        if s.get("buried_count") or s.get("suspended_count"):
+            lines.append((f"Buried {s.get('buried_count', 0)}   "
+                          f"Suspended {s.get('suspended_count', 0)}", DIM))
+
+        while True:
+            action = self.poll()
+            if action == "START":
+                return "QUIT"
+            if action in ("A", "B", "OTHER", "SELECT"):
+                return "CHILD_START"
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("¡Buen trabajo!", True, GOOD),
+                         56)
+            self._center(self.font_small.render("SESSION COMPLETE", True,
+                                                DIM), 108)
+            y = 160
+            for text, color in lines:
+                self._center(self.font.render(text, True, color), y)
+                y += 44
+            self._footer("A = Done   START = Quit")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    # -- parent mode -----------------------------------------------------------------
+
+    def screen_parent_menu(self):
+        direction = self.profile.get("study_direction", "normal")
+        entries = [
+            ("Import deck (.apkg)", "PARENT_IMPORT"),
+            ("Categories", "PARENT_CATEGORIES"),
+            ("Daily limits", "PARENT_LIMITS"),
+            ("Suspended cards", "PARENT_SUSPENDED"),
+            ("Progress", "PARENT_PROGRESS"),
+            (f"Direction: "
+             f"{'Reversed (back first)' if direction == 'reversed' else 'Normal (front first)'}",
+             "TOGGLE_DIRECTION"),
+            ("Back to study", "CHILD_START"),
+        ]
+        index = 0
+        while True:
+            action = self.poll()
+            if action in ("START", "B", "SELECT"):
+                return "CHILD_START"
+            if action == "UP":
+                index = (index - 1) % len(entries)
+            elif action == "DOWN":
+                index = (index + 1) % len(entries)
+            elif action == "A":
+                target = entries[index][1]
+                if target == "TOGGLE_DIRECTION":
+                    new = "normal" if direction == "reversed" else "reversed"
+                    self.storage.update_profile(self.profile["id"],
+                                                study_direction=new)
+                    self._reload_profile()
+                    return "PARENT_MENU"
+                return target
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("Parent Mode", True, FG), 44)
+            self._center(self.font_small.render(
+                f"Profile: {self.profile['name']}", True, DIM), 96)
+            y = 140
+            for i, (label, _) in enumerate(entries):
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                self.screen.blit(self.font.render(prefix + label, True,
+                                                  color), (90, y))
+                y += 42
+            self._footer("Up/Down = Choose   A = Select   B = Back")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def _scan_apkg_files(self):
+        """Places a parent might drop an .apkg: the data dir, an
+        import/ subfolder of it, the app folder, and the cwd."""
+        roots = [self.settings_dir(),
+                 os.path.join(self.settings_dir(), "import"),
+                 os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 os.getcwd()]
+        seen, found = set(), []
+        for root in roots:
+            if not root or not os.path.isdir(root):
+                continue
+            for name in sorted(os.listdir(root)):
+                if name.lower().endswith(".apkg"):
+                    path = os.path.join(root, name)
+                    if path not in seen:
+                        seen.add(path)
+                        found.append(path)
+        return found
+
+    def settings_dir(self):
+        return os.path.dirname(os.path.abspath(self.settings.path))
+
+    def screen_parent_import(self):
+        files = self._scan_apkg_files()
+        index = 0
+        message = None
+        while True:
+            action = self.poll()
+            if action in ("START", "B", "SELECT"):
+                return "PARENT_MENU"
+            if files and action == "UP":
+                index = (index - 1) % len(files)
+            elif files and action == "DOWN":
+                index = (index + 1) % len(files)
+            elif files and action == "A":
+                self._draw_import(files, index, "Importing…")
+                pygame.display.flip()
+                try:
+                    stats = import_apkg(
+                        files[index], self.storage,
+                        self.service.scheduler,
+                        os.path.join(self.settings_dir(), "media"))
+                    message = stats.summary()
+                except (ApkgError, OSError) as exc:
+                    message = f"Import failed: {exc}"
+
+            self._draw_import(files, index, message)
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def _draw_import(self, files, index, message):
+        self.screen.fill(BG)
+        self._center(self.font_big.render("Import Deck", True, FG), 40)
+        if not files:
+            self._center(self.font.render("No .apkg files found.", True,
+                                          DIM), 160)
+            self._center(self.font_small.render(
+                "Copy a deck into the data/ folder on the SD card.",
+                True, DIM), 210)
+        else:
+            y = 110
+            for i, path in enumerate(files[:7]):
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                self.screen.blit(self.font.render(
+                    prefix + os.path.basename(path), True, color), (70, y))
+                y += 38
+        if message:
+            y = self.h - 160
+            for line in wrap_text(self.font_small, message, self.w - 80):
+                self._center(self.font_small.render(line, True, WARN), y)
+                y += 24
+        self._footer("A = Import   B = Back")
+
+    def screen_parent_categories(self):
+        tags = self.storage.all_tags()
+        active = self.profile["active_categories"]
+        selected = None if active is None else set(active)
+        index = 0
+        entries = ["[ All categories ]"] + tags
+        top = 0
+        visible = 7
+
+        def save():
+            self.storage.update_profile(
+                self.profile["id"],
+                active_categories=(None if selected is None
+                                   else sorted(selected)))
+            self._reload_profile()
+
+        while True:
+            action = self.poll()
+            if action in ("START", "B", "SELECT"):
+                save()
+                return "PARENT_MENU"
+            if action == "UP":
+                index = (index - 1) % len(entries)
+            elif action == "DOWN":
+                index = (index + 1) % len(entries)
+            elif action == "A":
+                if index == 0:
+                    selected = None
+                else:
+                    tag = entries[index]
+                    if selected is None:
+                        selected = {tag}
+                    elif tag in selected:
+                        selected.discard(tag)
+                    else:
+                        selected.add(tag)
+            top = min(max(top, index - visible + 1), index)
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("Categories", True, FG), 36)
+            self._center(self.font_small.render(
+                "Choose what the child studies", True, DIM), 86)
+            y = 120
+            for i in range(top, min(top + visible, len(entries))):
+                label = entries[i]
+                if i == 0:
+                    mark = "(x)" if selected is None else "( )"
+                else:
+                    on = selected is None or label in selected
+                    mark = "[x]" if on else "[ ]"
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                self.screen.blit(self.font.render(
+                    f"{prefix}{mark} {label}", True, color), (80, y))
+                y += 40
+            if not tags:
+                self._center(self.font.render(
+                    "No tags found — import a deck first.", True, DIM), 200)
+            self._footer("A = Toggle   B = Save & back")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def screen_parent_limits(self):
+        fields = [
+            ("New cards per day", "daily_new_cards", 0, 100),
+            ("Review cards per day", "daily_review_cards", 0, 300),
+            ("Cards per session", "session_card_limit", 1, 200),
+            ("Minutes per session (0 = off)", "session_time_minutes", 0, 90),
+        ]
+        values = {key: self.profile[key] for _, key, _, _ in fields}
+        index = 0
+        while True:
+            action = self.poll()
+            if action in ("START", "B", "SELECT"):
+                self.storage.update_profile(self.profile["id"], **values)
+                self._reload_profile()
+                return "PARENT_MENU"
+            if action == "UP":
+                index = (index - 1) % len(fields)
+            elif action == "DOWN":
+                index = (index + 1) % len(fields)
+            elif action in ("LEFT", "RIGHT"):
+                label, key, lo, hi = fields[index]
+                step = -1 if action == "LEFT" else 1
+                values[key] = min(max(values[key] + step, lo), hi)
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("Daily Limits", True, FG), 40)
+            y = 140
+            for i, (label, key, _, _) in enumerate(fields):
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                self.screen.blit(self.font.render(prefix + label, True,
+                                                  color), (70, y))
+                value = self.font.render(str(values[key]), True, color)
+                self.screen.blit(value, (self.w - 120, y))
+                y += 52
+            self._footer("Left/Right = Adjust   B = Save & back")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def screen_parent_suspended(self):
+        index, top, visible = 0, 0, 7
+        cards = self.storage.suspended_cards()
+        while True:
+            action = self.poll()
+            if action in ("START", "B", "SELECT"):
+                return "PARENT_MENU"
+            if cards:
+                if action == "UP":
+                    index = (index - 1) % len(cards)
+                elif action == "DOWN":
+                    index = (index + 1) % len(cards)
+                elif action == "A":
+                    self.service.unsuspend_card(cards[index]["id"])
+                    cards = self.storage.suspended_cards()
+                    index = max(index - 1, 0)
+            index = min(index, max(len(cards) - 1, 0))
+            top = min(max(top, index - visible + 1), index) if cards else 0
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("Suspended Cards", True, FG),
+                         36)
+            if not cards:
+                self._center(self.font.render("No suspended cards.", True,
+                                              DIM), 200)
+            y = 110
+            for i in range(top, min(top + visible, len(cards))):
+                card = cards[i]
+                text = card["front"].replace("\n", " ")
+                if len(text) > 38:
+                    text = text[:37] + "…"
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                self.screen.blit(self.font.render(prefix + text, True,
+                                                  color), (60, y))
+                y += 40
+            self._footer("A = Unsuspend   B = Back")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def screen_parent_progress(self):
+        totals = self.service.recent_daily_totals(7)
+        suspended = len(self.storage.suspended_cards())
+        total_cards = self.storage.conn.execute(
+            "SELECT COUNT(*) AS n FROM cards").fetchone()["n"]
+        while True:
+            action = self.poll()
+            if action in ("START", "A", "B", "SELECT"):
+                return "PARENT_MENU"
+
+            self.screen.fill(BG)
+            self._center(self.font_big.render("Progress", True, FG), 36)
+            self._center(self.font_small.render(
+                f"{self.profile['name']}  ·  {total_cards} cards  ·  "
+                f"{suspended} suspended", True, DIM), 88)
+            y = 130
+            header = self.font_small.render(
+                "Day            Reviews    New", True, DIM)
+            self.screen.blit(header, (150, y))
+            y += 30
+            for day, reviews, new in totals:
+                label = day.strftime("%a %b %d")
+                row = f"{label:<14} {reviews:>7} {new:>6}"
+                self.screen.blit(self.font.render(row, True, FG), (150, y))
+                y += 38
+            self._footer("B = Back")
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    # -- drawing helpers ----------------------------------------------------------------
+
+    def _center(self, surf, y):
+        self.screen.blit(surf, ((self.w - surf.get_width()) // 2, y))
+
+    def _block(self, text, font, color, top, max_width):
+        y = top
+        for line in wrap_text(font, text, max_width):
+            if y > self.h - 80:
+                break  # clip very long cards; no scrolling
+            surf = font.render(line, True, color)
+            self.screen.blit(surf, ((self.w - surf.get_width()) // 2, y))
+            y += font.get_linesize()
+        return y
+
+    def _footer(self, text):
+        pygame.draw.line(self.screen, DIVIDER, (16, self.h - 44),
+                         (self.w - 16, self.h - 44))
+        surf = self.font_small.render(text, True, DIM)
+        self.screen.blit(surf, ((self.w - surf.get_width()) // 2,
+                                self.h - 33))

--- a/cardbrick-py/cardbrick/audio.py
+++ b/cardbrick-py/cardbrick/audio.py
@@ -19,6 +19,13 @@ class AudioPlayer:
         except pygame.error:
             self.enabled = False
 
+    def available(self, filename):
+        """True if the media file exists locally (missing-audio check)."""
+        if not filename:
+            return False
+        return os.path.exists(
+            os.path.join(self.media_dir, os.path.basename(filename)))
+
     def play(self, filename):
         """Play a media file by its imported name. Returns True if played."""
         if not self.enabled or not filename:

--- a/cardbrick-py/cardbrick/importer.py
+++ b/cardbrick-py/cardbrick/importer.py
@@ -22,6 +22,7 @@ import sqlite3
 import tempfile
 import zipfile
 
+from .scheduler import iso, now_utc
 from .textutil import clean_html, extract_audio
 
 AUDIO_EXTENSIONS = {".mp3", ".ogg", ".wav", ".flac", ".m4a", ".opus"}
@@ -36,16 +37,31 @@ class ApkgError(Exception):
 class ImportStats:
     def __init__(self):
         self.decks = set()
+        self.tags = set()
         self.cards = 0
         self.notes = 0
         self.media_files = 0
-        self.skipped_cards = 0
+        self.skipped = []  # (card_id, reason) for auditing
+
+    @property
+    def skipped_cards(self):
+        return len(self.skipped)
+
+    def skip(self, card_id, reason):
+        self.skipped.append((card_id, reason))
 
     def summary(self):
-        return (f"Imported {self.cards} cards from {self.notes} notes "
+        text = (f"Imported {self.cards} cards from {self.notes} notes "
                 f"into {len(self.decks)} deck(s); "
                 f"{self.media_files} media files copied; "
                 f"{self.skipped_cards} unsupported cards skipped.")
+        if self.skipped:
+            reasons = {}
+            for _cid, reason in self.skipped:
+                reasons[reason] = reasons.get(reason, 0) + 1
+            details = ", ".join(f"{n}x {r}" for r, n in sorted(reasons.items()))
+            text += f"\nSkipped: {details}"
+        return text
 
 
 def import_apkg(apkg_path, storage, scheduler, media_dir):
@@ -92,18 +108,18 @@ def _import_collection(col_path, storage, scheduler, stats):
         for card in conn.execute("SELECT id, nid, did, ord FROM cards"):
             note = notes.get(card["nid"])
             if note is None:
-                stats.skipped_cards += 1
+                stats.skip(card["id"], "orphan card (missing note)")
                 continue
             model = models.get(str(note["mid"])) or models.get(note["mid"])
             if model and model.get("type") == CLOZE_MODEL_TYPE:
-                stats.skipped_cards += 1
+                stats.skip(card["id"], "cloze note type")
                 continue
 
             fields = note["flds"].split("\x1f")
             if len(fields) < 2 or card["ord"] > 1:
                 # Only front/back pairs from the first two fields are
                 # supported (Basic and Basic (and reversed card)).
-                stats.skipped_cards += 1
+                stats.skip(card["id"], "unsupported template/fields")
                 continue
             front_raw, back_raw = fields[0], fields[1]
             if card["ord"] == 1:
@@ -114,7 +130,7 @@ def _import_collection(col_path, storage, scheduler, stats):
             front = clean_html(front_raw)
             back = clean_html(back_raw)
             if not front and not back:
-                stats.skipped_cards += 1
+                stats.skip(card["id"], "empty after HTML stripping")
                 continue
 
             audio_filename, audio_side = None, None
@@ -125,14 +141,17 @@ def _import_collection(col_path, storage, scheduler, stats):
 
             deck = decks.get(str(card["did"]),
                              decks.get(card["did"], "Default"))
+            tags = note["tags"].strip()
             storage.upsert_card(
                 card_id=card["id"], note_id=note["id"], deck=deck,
-                front=front, back=back, tags=note["tags"].strip(),
-                audio_filename=audio_filename, audio_side=audio_side)
+                front=front, back=back, tags=tags,
+                audio_filename=audio_filename, audio_side=audio_side,
+                now_iso=iso(now_utc()))
             storage.init_review_state(scheduler.initial_state(card["id"]))
 
             stats.cards += 1
             stats.decks.add(deck)
+            stats.tags.update(tags.split())
             notes_seen = getattr(stats, "_notes_seen", set())
             if note["id"] not in notes_seen:
                 notes_seen.add(note["id"])

--- a/cardbrick-py/cardbrick/service.py
+++ b/cardbrick-py/cardbrick/service.py
@@ -1,0 +1,214 @@
+"""Application-level review operations.
+
+The rest of the app talks to ``ReviewService`` and never manipulates
+FSRS internals directly. The service composes storage.py (persistence)
+and scheduler.py (the py-fsrs wrapper) into the operations the spec
+names:
+
+    get_due_cards(profile, category_filter, limits)
+    answer_card(card_id, rating, elapsed_ms)
+    undo_last_answer()
+    bury_card(card_id)
+    suspend_card(card_id)
+
+Time is injected (``now_fn``) so daily-rollover behaviour is testable.
+All daily accounting is derived from the append-only review log rather
+than in-memory counters, which makes it correct across undo, crashes,
+and restarts.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from .scheduler import ReviewScheduler, iso, now_utc
+
+# How far ahead of schedule an intra-session learning card may be shown.
+# Matches Anki's default "learn ahead" behaviour: a card rated Again is
+# due in ~1 minute and should come back within the same session.
+LEARN_AHEAD = timedelta(minutes=20)
+
+DEFAULT_LIMITS = {
+    "daily_new_cards": 10,
+    "daily_review_cards": 40,
+    "session_card_limit": 50,
+    "session_time_minutes": 15,
+}
+
+
+def local_day_start(now):
+    """UTC datetime of local midnight for the day containing ``now``."""
+    local = now.astimezone()
+    start = local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return start.astimezone(timezone.utc)
+
+
+def next_local_midnight(now):
+    """UTC datetime of the next local midnight (used for burying)."""
+    local = now.astimezone()
+    start = local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return (start + timedelta(days=1)).astimezone(timezone.utc)
+
+
+def card_matches_categories(tags_str, active_categories):
+    """True if a card's tag string matches the active category filter.
+
+    ``active_categories`` of None means "all categories". An explicit
+    list excludes untagged cards and cards with no matching tag.
+    """
+    if active_categories is None:
+        return True
+    return bool(set(tags_str.split()) & set(active_categories))
+
+
+class ReviewService:
+    def __init__(self, storage, scheduler=None, now_fn=None):
+        self.storage = storage
+        self.scheduler = scheduler or ReviewScheduler()
+        self.now_fn = now_fn or now_utc
+
+    def now(self):
+        return self.now_fn()
+
+    # -- queue building --------------------------------------------------------
+
+    def get_due_cards(self, profile=None, category_filter=None, limits=None):
+        """Build the capped review queue for a study session.
+
+        Order: due review cards (most overdue first), then new cards.
+        Suspended and buried cards never appear. Daily caps subtract
+        work already logged today, so a backlog can never flood a child
+        and restarting mid-day continues from where the day left off.
+
+        Returns a list of card rows (joined with review state).
+        """
+        limits = dict(DEFAULT_LIMITS, **(limits or {}))
+        if profile:
+            for key in DEFAULT_LIMITS:
+                if profile.get(key) is not None:
+                    limits[key] = profile[key]
+            if category_filter is None:
+                category_filter = profile.get("active_categories")
+
+        now = self.now()
+        new_done, review_done, _ = self.storage.daily_counts(
+            iso(local_day_start(now)))
+        remaining_new = max(limits["daily_new_cards"] - new_done, 0)
+        remaining_review = max(
+            limits["daily_review_cards"] - review_done, 0)
+
+        queue = []
+        for row in self.storage.queue_candidates(iso(now), new_cards=False):
+            if remaining_review <= 0:
+                break
+            if card_matches_categories(row["tags"], category_filter):
+                queue.append(row)
+                remaining_review -= 1
+        for row in self.storage.queue_candidates(iso(now), new_cards=True):
+            if remaining_new <= 0:
+                break
+            if card_matches_categories(row["tags"], category_filter):
+                queue.append(row)
+                remaining_new -= 1
+
+        return queue[:limits["session_card_limit"]]
+
+    def counts_for_queue(self, profile=None, category_filter=None,
+                         limits=None):
+        """(review, new) counts of what get_due_cards would return."""
+        queue = self.get_due_cards(profile, category_filter, limits)
+        new = sum(1 for row in queue if row["reps"] == 0)
+        return len(queue) - new, new
+
+    # -- answering ---------------------------------------------------------------
+
+    def answer_card(self, card_id, rating, elapsed_ms=None, session_id=None):
+        """Apply a 1-4 rating; returns (new_state, came_back_soon).
+
+        The previous state is snapshotted into the append-only review
+        log *in the same transaction* as the state mutation, so undo is
+        an exact restore, never a guess. ``came_back_soon`` tells the
+        session to requeue the card (learning steps due within
+        LEARN_AHEAD).
+        """
+        now = self.now()
+        state_row = self.storage.get_review_state(card_id)
+        if state_row is None:
+            raise KeyError(f"card {card_id} has no review state")
+        previous = dict(state_row)
+        was_new = previous["reps"] == 0
+
+        new_state = self.scheduler.review(state_row, rating, now=now)
+
+        self.storage.append_review_log(
+            card_id=card_id, reviewed_at=iso(now), rating=int(rating),
+            elapsed_ms=elapsed_ms, was_new=was_new,
+            previous_state_json=json.dumps(previous),
+            new_state_json=json.dumps(new_state),
+            session_id=session_id)
+        # save_review_state commits, making the log append and the state
+        # mutation one durable unit (auto-save after every answer).
+        self.storage.save_review_state(new_state, last_reviewed_at=iso(now))
+
+        due = datetime.fromisoformat(new_state["due"])
+        return new_state, due <= now + LEARN_AHEAD
+
+    def undo_last_answer(self, session_id):
+        """Roll back the most recent answer of a session exactly.
+
+        Restores the snapshotted prior FSRS state (due date, reps,
+        lapses, card state) and marks the log entry undone so daily and
+        session counters — all derived from the log — correct
+        themselves. Returns the card_id, or None if nothing to undo.
+        """
+        entry = self.storage.last_review_log(session_id)
+        if entry is None:
+            return None
+        previous = json.loads(entry["previous_state_json"])
+        self.storage.restore_review_state(previous)
+        self.storage.mark_log_undone(entry["id"])
+        self.storage.commit()
+        return entry["card_id"]
+
+    # -- bury / suspend ------------------------------------------------------------
+
+    def bury_card(self, card_id, session_id=None):
+        """Hide a card until tomorrow ("not now")."""
+        now = self.now()
+        self.storage.set_buried_until(
+            card_id, iso(next_local_midnight(now)), now_iso=iso(now))
+        if session_id is not None:
+            self.storage.bump_session_counter(session_id, "buried_count")
+
+    def suspend_card(self, card_id, session_id=None):
+        """Hide a card indefinitely ("bad card, parent should fix")."""
+        now_iso = iso(self.now())
+        self.storage.set_suspended(card_id, True, now_iso=now_iso)
+        if session_id is not None:
+            self.storage.bump_session_counter(session_id, "suspended_count")
+
+    def unsuspend_card(self, card_id):
+        self.storage.set_suspended(card_id, False, now_iso=iso(self.now()))
+
+    # -- progress ---------------------------------------------------------------------
+
+    def recent_daily_totals(self, days=7):
+        """[(local_date, reviews, new)] for the last ``days`` days."""
+        now = self.now()
+        since = local_day_start(now) - timedelta(days=days - 1)
+        per_day = {}
+        first_seen_new = set()
+        for row in self.storage.daily_history(iso(since)):
+            when = datetime.fromisoformat(row["reviewed_at"]).astimezone()
+            day = when.date()
+            entry = per_day.setdefault(day, {"reviews": set(), "new": set()})
+            if row["was_new"] and row["card_id"] not in first_seen_new:
+                first_seen_new.add(row["card_id"])
+                entry["new"].add(row["card_id"])
+            else:
+                entry["reviews"].add(row["card_id"])
+        result = []
+        for offset in range(days - 1, -1, -1):
+            day = (now.astimezone() - timedelta(days=offset)).date()
+            entry = per_day.get(day, {"reviews": set(), "new": set()})
+            result.append((day, len(entry["reviews"]), len(entry["new"])))
+        return result

--- a/cardbrick-py/cardbrick/session.py
+++ b/cardbrick-py/cardbrick/session.py
@@ -1,0 +1,146 @@
+"""Study session runner.
+
+Owns the card queue for one sitting: pops cards, applies answers through
+ReviewService, requeues intra-session learning cards, tracks the session
+row in the database, and produces the end-of-session summary. All
+counters are derived from the append-only review log, so a crash mid-
+session loses nothing and undo corrects the numbers automatically.
+"""
+
+from collections import deque
+from datetime import datetime
+
+from .scheduler import iso
+
+
+class StudySession:
+    def __init__(self, storage, service, profile):
+        self.storage = storage
+        self.service = service
+        self.profile = profile
+        self.started_at = service.now()
+        self.session_id = storage.create_session(
+            profile_id=profile["id"],
+            started_at=iso(self.started_at),
+            category_filter=profile.get("active_categories"))
+
+        rows = service.get_due_cards(profile=profile)
+        self.queue = deque(row["id"] for row in rows)
+        self.planned_total = len(rows)
+        self.finished = False
+        self._current = None
+
+    # -- flow -------------------------------------------------------------------
+
+    def current_card(self):
+        """The card to show now, or None when the session is complete.
+
+        Skips cards that were buried/suspended while queued (e.g. via
+        undo + bury) by re-checking the row at pop time.
+        """
+        while self._current is None and self.queue:
+            row = self.storage.get_card(self.queue[0])
+            if row is None or row["suspended"]:
+                self.queue.popleft()
+                continue
+            self._current = row
+            break
+        return self._current
+
+    def answer(self, rating, elapsed_ms=None):
+        """Rate the current card; requeues it if a learning step brings
+        it back within this session."""
+        card = self._pop_current()
+        _state, comes_back = self.service.answer_card(
+            card["id"], rating, elapsed_ms=elapsed_ms,
+            session_id=self.session_id)
+        if comes_back:
+            self.queue.append(card["id"])
+        return comes_back
+
+    def undo(self):
+        """Undo the previous answer and put that card back up front.
+
+        Returns the restored card row, or None if there was nothing to
+        undo in this session.
+        """
+        card_id = self.service.undo_last_answer(self.session_id)
+        if card_id is None:
+            return None
+        # Remove any requeued copy, then show the card again immediately.
+        try:
+            self.queue.remove(card_id)
+        except ValueError:
+            pass
+        self.queue.appendleft(card_id)
+        self._current = None
+        return self.current_card()
+
+    def bury_current(self):
+        card = self._pop_current()
+        self.service.bury_card(card["id"], session_id=self.session_id)
+
+    def suspend_current(self):
+        card = self._pop_current()
+        self.service.suspend_card(card["id"], session_id=self.session_id)
+
+    def _pop_current(self):
+        card = self.current_card()
+        if card is None:
+            raise RuntimeError("No current card")
+        self.queue.popleft()
+        self._current = None
+        return card
+
+    # -- status -------------------------------------------------------------------
+
+    def remaining(self):
+        return len(self.queue)
+
+    def elapsed_seconds(self):
+        return (self.service.now() - self.started_at).total_seconds()
+
+    def time_limit_reached(self):
+        minutes = self.profile.get("session_time_minutes")
+        if not minutes:
+            return False
+        return self.elapsed_seconds() >= minutes * 60
+
+    def is_done(self):
+        return self.finished or self.current_card() is None
+
+    # -- finish ---------------------------------------------------------------------
+
+    def finish(self):
+        if not self.finished:
+            self.finished = True
+            self.storage.finish_session(self.session_id,
+                                        iso(self.service.now()))
+        return self.summary()
+
+    def summary(self):
+        """Concise end-of-session stats for the summary screen."""
+        counts = self.storage.session_counts(self.session_id)
+        row = self.storage.session_row(self.session_id)
+        reviewed = counts["cards_reviewed"]
+        passed = reviewed - counts["again_count"]
+        ended = (datetime.fromisoformat(row["ended_at"])
+                 if row["ended_at"] else self.service.now())
+        started = datetime.fromisoformat(row["started_at"])
+        return {
+            "cards_reviewed": reviewed,
+            "unique_cards": counts["unique_cards"],
+            "new_cards": counts["new_cards"],
+            "review_cards": counts["review_cards"],
+            "again_count": counts["again_count"],
+            "hard_count": counts["hard_count"],
+            "good_count": counts["good_count"],
+            "easy_count": counts["easy_count"],
+            "pass_rate": (passed / reviewed) if reviewed else None,
+            "time_spent_seconds": max(
+                (ended - started).total_seconds(), 0),
+            "avg_response_ms": (counts["elapsed_ms"] / reviewed)
+                               if reviewed and counts["elapsed_ms"] else None,
+            "buried_count": row["buried_count"],
+            "suspended_count": row["suspended_count"],
+        }

--- a/cardbrick-py/cardbrick/settings.py
+++ b/cardbrick-py/cardbrick/settings.py
@@ -1,0 +1,48 @@
+"""App settings, persisted as plain JSON next to the database.
+
+Durable and user-editable on purpose: a parent can fix a bad setting
+with a text editor on the SD card. Unknown keys are preserved.
+"""
+
+import json
+import os
+
+DEFAULTS = {
+    "current_child_profile_id": None,
+    "auto_play_audio": True,
+    "fullscreen": False,
+    "logical_width": 640,
+    "logical_height": 480,
+}
+
+
+class AppSettings:
+    def __init__(self, path):
+        self.path = path
+        self.data = dict(DEFAULTS)
+        self.load()
+
+    def load(self):
+        try:
+            with open(self.path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                self.data.update(loaded)
+        except (OSError, json.JSONDecodeError):
+            pass  # missing or corrupt file: fall back to defaults
+        return self
+
+    def save(self):
+        os.makedirs(os.path.dirname(os.path.abspath(self.path)),
+                    exist_ok=True)
+        tmp = self.path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(self.data, f, indent=2, sort_keys=True)
+        os.replace(tmp, self.path)  # atomic: never a half-written file
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def set(self, key, value):
+        self.data[key] = value
+        self.save()

--- a/cardbrick-py/cardbrick/storage.py
+++ b/cardbrick-py/cardbrick/storage.py
@@ -1,14 +1,27 @@
 """Local SQLite storage.
 
-Owns the application database: imported cards plus FSRS review state.
-Nothing here knows about .apkg files, pygame, or the FSRS algorithm —
-review_state rows are written from dicts produced by scheduler.py.
+Owns the application database: imported cards, FSRS review state, the
+append-only review log, study sessions, and child profiles. Nothing here
+knows about .apkg files, pygame, or the FSRS algorithm — review_state
+rows are written from dicts produced by scheduler.py.
+
+The schema is versioned through the ``meta`` table and migrates in place,
+so databases created by the original prototype keep their review
+progress when opened by the CardBrick-style app.
 """
 
+import json
 import os
 import sqlite3
 
+SCHEMA_VERSION = 2
+
 SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+
 CREATE TABLE IF NOT EXISTS cards (
     id             INTEGER PRIMARY KEY,
     note_id        INTEGER NOT NULL,
@@ -17,25 +30,85 @@ CREATE TABLE IF NOT EXISTS cards (
     back           TEXT NOT NULL,
     tags           TEXT NOT NULL DEFAULT '',
     audio_filename TEXT,
-    audio_side     TEXT CHECK (audio_side IN ('front', 'back') OR audio_side IS NULL)
+    audio_side     TEXT CHECK (audio_side IN ('front', 'back') OR audio_side IS NULL),
+    suspended      INTEGER NOT NULL DEFAULT 0,
+    buried_until   TEXT,
+    created_at     TEXT,
+    updated_at     TEXT
 );
 
 CREATE TABLE IF NOT EXISTS review_state (
-    card_id        INTEGER PRIMARY KEY REFERENCES cards(id) ON DELETE CASCADE,
-    due            TEXT NOT NULL,
-    stability      REAL,
-    difficulty     REAL,
-    elapsed_days   INTEGER NOT NULL DEFAULT 0,
-    scheduled_days INTEGER NOT NULL DEFAULT 0,
-    reps           INTEGER NOT NULL DEFAULT 0,
-    lapses         INTEGER NOT NULL DEFAULT 0,
-    state          INTEGER NOT NULL,
-    fsrs_json      TEXT NOT NULL
+    card_id          INTEGER PRIMARY KEY REFERENCES cards(id) ON DELETE CASCADE,
+    due              TEXT NOT NULL,
+    stability        REAL,
+    difficulty       REAL,
+    elapsed_days     INTEGER NOT NULL DEFAULT 0,
+    scheduled_days   INTEGER NOT NULL DEFAULT 0,
+    reps             INTEGER NOT NULL DEFAULT 0,
+    lapses           INTEGER NOT NULL DEFAULT 0,
+    state            INTEGER NOT NULL,
+    fsrs_json        TEXT NOT NULL,
+    last_reviewed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS review_log (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_id             INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+    reviewed_at         TEXT NOT NULL,
+    rating              INTEGER NOT NULL,
+    elapsed_ms          INTEGER,
+    was_new             INTEGER NOT NULL DEFAULT 0,
+    previous_state_json TEXT NOT NULL,
+    new_state_json      TEXT NOT NULL,
+    session_id          INTEGER,
+    undone              INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_id      INTEGER,
+    started_at      TEXT NOT NULL,
+    ended_at        TEXT,
+    category_filter TEXT,
+    cards_reviewed  INTEGER NOT NULL DEFAULT 0,
+    new_cards       INTEGER NOT NULL DEFAULT 0,
+    review_cards    INTEGER NOT NULL DEFAULT 0,
+    again_count     INTEGER NOT NULL DEFAULT 0,
+    hard_count      INTEGER NOT NULL DEFAULT 0,
+    good_count      INTEGER NOT NULL DEFAULT 0,
+    easy_count      INTEGER NOT NULL DEFAULT 0,
+    buried_count    INTEGER NOT NULL DEFAULT 0,
+    suspended_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS child_profiles (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name                 TEXT NOT NULL,
+    active_categories    TEXT,
+    daily_new_cards      INTEGER NOT NULL DEFAULT 10,
+    daily_review_cards   INTEGER NOT NULL DEFAULT 40,
+    session_card_limit   INTEGER NOT NULL DEFAULT 50,
+    session_time_minutes INTEGER NOT NULL DEFAULT 15,
+    study_direction      TEXT NOT NULL DEFAULT 'normal'
 );
 
 CREATE INDEX IF NOT EXISTS idx_cards_deck ON cards(deck);
 CREATE INDEX IF NOT EXISTS idx_review_due ON review_state(due);
+CREATE INDEX IF NOT EXISTS idx_log_session ON review_log(session_id);
+CREATE INDEX IF NOT EXISTS idx_log_reviewed_at ON review_log(reviewed_at);
 """
+
+# Columns added to prototype-era tables; applied with ALTER TABLE when a
+# pre-versioned database is opened.
+_CARD_UPGRADES = {
+    "suspended": "INTEGER NOT NULL DEFAULT 0",
+    "buried_until": "TEXT",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+_STATE_UPGRADES = {
+    "last_reviewed_at": "TEXT",
+}
 
 
 class Storage:
@@ -44,26 +117,53 @@ class Storage:
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
         self.conn.execute("PRAGMA foreign_keys = ON")
+        self._migrate()
+
+    def _migrate(self):
+        self._upgrade_table("cards", _CARD_UPGRADES)
+        self._upgrade_table("review_state", _STATE_UPGRADES)
         self.conn.executescript(SCHEMA)
+        self.conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES "
+            "('schema_version', ?)", (str(SCHEMA_VERSION),))
+        self.conn.commit()
+
+    def _upgrade_table(self, table, upgrades):
+        row = self.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table,)).fetchone()
+        if row is None:
+            return
+        existing = {r["name"] for r in
+                    self.conn.execute(f"PRAGMA table_info({table})")}
+        for column, decl in upgrades.items():
+            if column not in existing:
+                self.conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
 
     def close(self):
         self.conn.close()
 
+    def commit(self):
+        self.conn.commit()
+
     # -- import-side writes -------------------------------------------------
 
     def upsert_card(self, card_id, note_id, deck, front, back, tags,
-                    audio_filename=None, audio_side=None):
+                    audio_filename=None, audio_side=None, now_iso=None):
         self.conn.execute(
             """INSERT INTO cards (id, note_id, deck, front, back, tags,
-                                  audio_filename, audio_side)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                                  audio_filename, audio_side,
+                                  created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(id) DO UPDATE SET
                    note_id=excluded.note_id, deck=excluded.deck,
                    front=excluded.front, back=excluded.back,
                    tags=excluded.tags, audio_filename=excluded.audio_filename,
-                   audio_side=excluded.audio_side""",
+                   audio_side=excluded.audio_side,
+                   updated_at=excluded.updated_at""",
             (card_id, note_id, deck, front, back, tags,
-             audio_filename, audio_side))
+             audio_filename, audio_side, now_iso, now_iso))
 
     def init_review_state(self, state):
         """Insert initial FSRS state for a card, unless one already exists.
@@ -78,21 +178,290 @@ class Storage:
                        :scheduled_days, :reps, :lapses, :state, :fsrs_json)""",
             state)
 
-    def commit(self):
-        self.conn.commit()
+    # -- card reads -----------------------------------------------------------
 
-    # -- review-side reads/writes -------------------------------------------
+    def get_card(self, card_id):
+        """A card joined with its review state (the shape the UI consumes)."""
+        return self.conn.execute(
+            """SELECT c.*, r.due, r.reps, r.lapses, r.state AS fsrs_state,
+                      r.fsrs_json
+               FROM cards c JOIN review_state r ON r.card_id = c.id
+               WHERE c.id = ?""", (card_id,)).fetchone()
 
-    def save_review_state(self, state):
+    def get_review_state(self, card_id):
+        return self.conn.execute(
+            "SELECT * FROM review_state WHERE card_id = ?",
+            (card_id,)).fetchone()
+
+    def all_tags(self):
+        """Sorted distinct tags across all cards."""
+        tags = set()
+        for row in self.conn.execute("SELECT DISTINCT tags FROM cards"):
+            tags.update(row["tags"].split())
+        return sorted(tags)
+
+    def queue_candidates(self, now_iso, new_cards=False):
+        """Cards eligible for the review queue, before tag filtering.
+
+        Excludes suspended cards and cards buried until later than now.
+        ``new_cards`` selects never-reviewed cards (reps = 0) ordered by
+        id; otherwise cards that are due now, most overdue first.
+        """
+        base = """SELECT c.*, r.due, r.reps, r.lapses,
+                         r.state AS fsrs_state, r.fsrs_json
+                  FROM cards c JOIN review_state r ON r.card_id = c.id
+                  WHERE c.suspended = 0
+                    AND (c.buried_until IS NULL OR c.buried_until <= :now)"""
+        if new_cards:
+            query = base + " AND r.reps = 0 ORDER BY c.id"
+        else:
+            query = base + " AND r.reps > 0 AND r.due <= :now ORDER BY r.due"
+        return self.conn.execute(query, {"now": now_iso}).fetchall()
+
+    def suspended_cards(self):
+        return self.conn.execute(
+            "SELECT * FROM cards WHERE suspended = 1 ORDER BY deck, id"
+        ).fetchall()
+
+    # -- review-side writes ---------------------------------------------------
+
+    def save_review_state(self, state, last_reviewed_at=None):
+        state = dict(state)
+        state["last_reviewed_at"] = last_reviewed_at
         self.conn.execute(
             """UPDATE review_state SET
                    due=:due, stability=:stability, difficulty=:difficulty,
                    elapsed_days=:elapsed_days, scheduled_days=:scheduled_days,
                    reps=:reps, lapses=:lapses, state=:state,
-                   fsrs_json=:fsrs_json
+                   fsrs_json=:fsrs_json,
+                   last_reviewed_at=:last_reviewed_at
                WHERE card_id=:card_id""",
             state)
         self.conn.commit()
+
+    def restore_review_state(self, state):
+        """Overwrite a card's review state from a snapshot dict (undo)."""
+        keys = ("due", "stability", "difficulty", "elapsed_days",
+                "scheduled_days", "reps", "lapses", "state", "fsrs_json",
+                "last_reviewed_at")
+        snapshot = {k: state.get(k) for k in keys}
+        snapshot["card_id"] = state["card_id"]
+        self.conn.execute(
+            """UPDATE review_state SET
+                   due=:due, stability=:stability, difficulty=:difficulty,
+                   elapsed_days=:elapsed_days, scheduled_days=:scheduled_days,
+                   reps=:reps, lapses=:lapses, state=:state,
+                   fsrs_json=:fsrs_json,
+                   last_reviewed_at=:last_reviewed_at
+               WHERE card_id=:card_id""",
+            snapshot)
+
+    def set_suspended(self, card_id, suspended, now_iso=None):
+        self.conn.execute(
+            "UPDATE cards SET suspended=?, updated_at=? WHERE id=?",
+            (1 if suspended else 0, now_iso, card_id))
+        self.conn.commit()
+
+    def set_buried_until(self, card_id, buried_until_iso, now_iso=None):
+        self.conn.execute(
+            "UPDATE cards SET buried_until=?, updated_at=? WHERE id=?",
+            (buried_until_iso, now_iso, card_id))
+        self.conn.commit()
+
+    # -- review log -----------------------------------------------------------
+
+    def append_review_log(self, card_id, reviewed_at, rating, elapsed_ms,
+                          was_new, previous_state_json, new_state_json,
+                          session_id):
+        cur = self.conn.execute(
+            """INSERT INTO review_log
+               (card_id, reviewed_at, rating, elapsed_ms, was_new,
+                previous_state_json, new_state_json, session_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (card_id, reviewed_at, rating, elapsed_ms, 1 if was_new else 0,
+             previous_state_json, new_state_json, session_id))
+        return cur.lastrowid
+
+    def last_review_log(self, session_id):
+        """Most recent not-undone log entry for a session."""
+        return self.conn.execute(
+            """SELECT * FROM review_log
+               WHERE session_id = ? AND undone = 0
+               ORDER BY id DESC LIMIT 1""", (session_id,)).fetchone()
+
+    def mark_log_undone(self, log_id):
+        self.conn.execute(
+            "UPDATE review_log SET undone = 1 WHERE id = ?", (log_id,))
+
+    def daily_counts(self, day_start_iso):
+        """Distinct cards introduced/reviewed since the local day start.
+
+        Returns (new_count, review_count, new_card_ids). A card whose
+        first-ever review happened today counts only as new, even if it
+        was answered again later the same day.
+        """
+        new_ids = {row["card_id"] for row in self.conn.execute(
+            """SELECT DISTINCT card_id FROM review_log
+               WHERE undone = 0 AND was_new = 1 AND reviewed_at >= ?""",
+            (day_start_iso,))}
+        all_ids = {row["card_id"] for row in self.conn.execute(
+            """SELECT DISTINCT card_id FROM review_log
+               WHERE undone = 0 AND reviewed_at >= ?""",
+            (day_start_iso,))}
+        return len(new_ids), len(all_ids - new_ids), new_ids
+
+    def daily_history(self, since_iso):
+        """Raw (reviewed_at, was_new, card_id) tuples for progress views."""
+        return self.conn.execute(
+            """SELECT reviewed_at, was_new, card_id FROM review_log
+               WHERE undone = 0 AND reviewed_at >= ?
+               ORDER BY reviewed_at""", (since_iso,)).fetchall()
+
+    # -- sessions ---------------------------------------------------------------
+
+    def create_session(self, profile_id, started_at, category_filter):
+        cur = self.conn.execute(
+            """INSERT INTO sessions (profile_id, started_at, category_filter)
+               VALUES (?, ?, ?)""",
+            (profile_id, started_at,
+             json.dumps(category_filter) if category_filter else None))
+        self.conn.commit()
+        return cur.lastrowid
+
+    def bump_session_counter(self, session_id, field):
+        if field not in ("buried_count", "suspended_count"):
+            raise ValueError(field)
+        self.conn.execute(
+            f"UPDATE sessions SET {field} = {field} + 1 WHERE id = ?",
+            (session_id,))
+        self.conn.commit()
+
+    def session_row(self, session_id):
+        return self.conn.execute(
+            "SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+
+    def session_counts(self, session_id):
+        """Aggregate review counters for a session from the review log.
+
+        Deriving these from the log (rather than mutating counters in
+        memory) makes them automatically correct across undo and crashes.
+        """
+        rows = self.conn.execute(
+            """SELECT card_id, rating, was_new, elapsed_ms FROM review_log
+               WHERE session_id = ? AND undone = 0""",
+            (session_id,)).fetchall()
+        counts = {"cards_reviewed": len(rows), "new_cards": 0,
+                  "review_cards": 0, "again_count": 0, "hard_count": 0,
+                  "good_count": 0, "easy_count": 0, "elapsed_ms": 0,
+                  "unique_cards": 0}
+        rating_field = {1: "again_count", 2: "hard_count",
+                        3: "good_count", 4: "easy_count"}
+        new_ids, all_ids = set(), set()
+        for row in rows:
+            counts[rating_field[row["rating"]]] += 1
+            counts["elapsed_ms"] += row["elapsed_ms"] or 0
+            all_ids.add(row["card_id"])
+            if row["was_new"]:
+                new_ids.add(row["card_id"])
+        counts["new_cards"] = len(new_ids)
+        counts["review_cards"] = len(all_ids - new_ids)
+        counts["unique_cards"] = len(all_ids)
+        return counts
+
+    def finish_session(self, session_id, ended_at):
+        """Stamp the end time and persist final aggregates from the log."""
+        counts = self.session_counts(session_id)
+        self.conn.execute(
+            """UPDATE sessions SET ended_at=?, cards_reviewed=?, new_cards=?,
+                   review_cards=?, again_count=?, hard_count=?, good_count=?,
+                   easy_count=?
+               WHERE id=?""",
+            (ended_at, counts["cards_reviewed"], counts["new_cards"],
+             counts["review_cards"], counts["again_count"],
+             counts["hard_count"], counts["good_count"],
+             counts["easy_count"], session_id))
+        self.conn.commit()
+
+    def close_dangling_sessions(self, fallback_ended_at):
+        """Finish sessions left open by a crash or power-off.
+
+        Reviews already answered were committed one by one, so nothing is
+        lost; the session just never got an end stamp.
+        """
+        open_ids = [row["id"] for row in self.conn.execute(
+            "SELECT id FROM sessions WHERE ended_at IS NULL")]
+        for session_id in open_ids:
+            last = self.conn.execute(
+                """SELECT MAX(reviewed_at) AS t FROM review_log
+                   WHERE session_id = ?""", (session_id,)).fetchone()
+            self.finish_session(session_id,
+                                last["t"] or fallback_ended_at)
+        return open_ids
+
+    # -- child profiles ---------------------------------------------------------
+
+    def create_profile(self, name, **fields):
+        allowed = {"active_categories", "daily_new_cards",
+                   "daily_review_cards", "session_card_limit",
+                   "session_time_minutes", "study_direction"}
+        unknown = set(fields) - allowed
+        if unknown:
+            raise ValueError(f"Unknown profile fields: {unknown}")
+        if "active_categories" in fields and \
+                fields["active_categories"] is not None:
+            fields["active_categories"] = json.dumps(
+                fields["active_categories"])
+        columns = ["name"] + list(fields)
+        values = [name] + list(fields.values())
+        cur = self.conn.execute(
+            f"""INSERT INTO child_profiles ({', '.join(columns)})
+                VALUES ({', '.join('?' * len(values))})""", values)
+        self.conn.commit()
+        return cur.lastrowid
+
+    def update_profile(self, profile_id, **fields):
+        allowed = {"name", "active_categories", "daily_new_cards",
+                   "daily_review_cards", "session_card_limit",
+                   "session_time_minutes", "study_direction"}
+        unknown = set(fields) - allowed
+        if unknown:
+            raise ValueError(f"Unknown profile fields: {unknown}")
+        if "active_categories" in fields and \
+                fields["active_categories"] is not None:
+            fields["active_categories"] = json.dumps(
+                fields["active_categories"])
+        sets = ", ".join(f"{k}=?" for k in fields)
+        self.conn.execute(
+            f"UPDATE child_profiles SET {sets} WHERE id=?",
+            list(fields.values()) + [profile_id])
+        self.conn.commit()
+
+    def get_profile(self, profile_id):
+        row = self.conn.execute(
+            "SELECT * FROM child_profiles WHERE id=?",
+            (profile_id,)).fetchone()
+        return self._profile_dict(row) if row else None
+
+    def list_profiles(self):
+        return [self._profile_dict(row) for row in self.conn.execute(
+            "SELECT * FROM child_profiles ORDER BY id")]
+
+    def ensure_default_profile(self, name="Student"):
+        """Return the first profile, creating one if none exist."""
+        profiles = self.list_profiles()
+        if profiles:
+            return profiles[0]
+        profile_id = self.create_profile(name)
+        return self.get_profile(profile_id)
+
+    @staticmethod
+    def _profile_dict(row):
+        profile = dict(row)
+        raw = profile.get("active_categories")
+        profile["active_categories"] = json.loads(raw) if raw else None
+        return profile
+
+    # -- legacy prototype queries (main.py review / decks) ------------------------
 
     def next_due_card(self, now_iso, deck=None):
         """The most overdue card, joined with its review state."""

--- a/cardbrick-py/main.py
+++ b/cardbrick-py/main.py
@@ -2,12 +2,16 @@
 """CardBrick-Py entry point.
 
 Usage:
-    python main.py import <deck.apkg>    Import an Anki package
-    python main.py review [--deck NAME]  Start the pygame reviewer
-    python main.py decks                 List decks and due counts
+    python main.py study [--fullscreen]     CardBrick-style study appliance
+                                            (child/parent flow; the default)
+    python main.py import <deck.apkg>       Import an Anki package
+    python main.py review [--deck NAME]     Legacy prototype reviewer
+    python main.py decks                    List decks and due counts
+    python main.py profile [...]            View/edit the child profile
 """
 
 import argparse
+import json
 import os
 import sys
 
@@ -27,19 +31,42 @@ def main(argv=None):
                              "(default: ./data)")
     sub = parser.add_subparsers(dest="command")
 
+    p_study = sub.add_parser(
+        "study", help="CardBrick-style study appliance (default)")
+    p_study.add_argument("--fullscreen", action="store_true",
+                         help="Run fullscreen (use on the handheld)")
+
     p_import = sub.add_parser("import", help="Import an .apkg file")
     p_import.add_argument("apkg", help="Path to the .apkg file")
 
-    p_review = sub.add_parser("review", help="Start the reviewer (default)")
+    p_review = sub.add_parser("review",
+                              help="Legacy prototype reviewer (no limits)")
     p_review.add_argument("--deck", help="Review only this deck")
     p_review.add_argument("--fullscreen", action="store_true",
                           help="Run fullscreen (use on the handheld)")
 
     sub.add_parser("decks", help="List decks and due counts")
 
+    p_profile = sub.add_parser("profile",
+                               help="View or edit the child profile")
+    p_profile.add_argument("--name", help="Child's name")
+    p_profile.add_argument("--daily-new", type=int,
+                           help="New cards per day")
+    p_profile.add_argument("--daily-review", type=int,
+                           help="Review cards per day")
+    p_profile.add_argument("--session-cards", type=int,
+                           help="Max cards per session")
+    p_profile.add_argument("--session-minutes", type=int,
+                           help="Max minutes per session (0 = no limit)")
+    p_profile.add_argument("--categories",
+                           help="Comma-separated active categories, "
+                                "or 'all' for every tag")
+    p_profile.add_argument("--direction", choices=["normal", "reversed"],
+                           help="Card direction")
+
     args = parser.parse_args(argv)
     if args.command is None:
-        args.command, args.deck, args.fullscreen = "review", None, False
+        args.command, args.fullscreen = "study", False
 
     db_path = os.path.join(args.data_dir, "cardbrick.db")
     media_dir = os.path.join(args.data_dir, "media")
@@ -57,12 +84,26 @@ def main(argv=None):
             for row in rows:
                 print(f"{row['name']}: {row['due']} due / "
                       f"{row['total']} total")
-        else:
+        elif args.command == "profile":
+            _profile_command(storage, args)
+        elif args.command == "review":
             from cardbrick.audio import AudioPlayer
             from cardbrick.ui import ReviewApp
             audio = AudioPlayer(media_dir)
             app = ReviewApp(storage, scheduler, audio,
                             deck=args.deck, fullscreen=args.fullscreen)
+            app.run()
+        else:  # study
+            from cardbrick.app import CardBrickApp
+            from cardbrick.audio import AudioPlayer
+            from cardbrick.service import ReviewService
+            from cardbrick.settings import AppSettings
+            settings = AppSettings(os.path.join(args.data_dir,
+                                                "settings.json"))
+            service = ReviewService(storage, scheduler)
+            audio = AudioPlayer(media_dir)
+            app = CardBrickApp(storage, service, audio, settings,
+                               fullscreen=args.fullscreen or None)
             app.run()
     except ApkgError as exc:
         print(f"Import failed: {exc}", file=sys.stderr)
@@ -70,6 +111,40 @@ def main(argv=None):
     finally:
         storage.close()
     return 0
+
+
+def _profile_command(storage, args):
+    profile = storage.ensure_default_profile()
+    updates = {}
+    if args.name:
+        updates["name"] = args.name
+    if args.daily_new is not None:
+        updates["daily_new_cards"] = args.daily_new
+    if args.daily_review is not None:
+        updates["daily_review_cards"] = args.daily_review
+    if args.session_cards is not None:
+        updates["session_card_limit"] = args.session_cards
+    if args.session_minutes is not None:
+        updates["session_time_minutes"] = args.session_minutes
+    if args.direction:
+        updates["study_direction"] = args.direction
+    if args.categories:
+        if args.categories.strip().lower() == "all":
+            updates["active_categories"] = None
+        else:
+            updates["active_categories"] = [
+                c.strip() for c in args.categories.split(",") if c.strip()]
+        # update_profile serializes lists; None means "all categories"
+        storage.update_profile(profile["id"],
+                               active_categories=updates.pop(
+                                   "active_categories"))
+    if updates:
+        storage.update_profile(profile["id"], **updates)
+    profile = storage.get_profile(profile["id"])
+    print(json.dumps(profile, indent=2))
+    tags = storage.all_tags()
+    if tags:
+        print("Available categories: " + ", ".join(tags))
 
 
 if __name__ == "__main__":

--- a/cardbrick-py/tests/conftest.py
+++ b/cardbrick-py/tests/conftest.py
@@ -1,0 +1,71 @@
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from cardbrick.scheduler import ReviewScheduler, iso  # noqa: E402
+from cardbrick.service import ReviewService  # noqa: E402
+from cardbrick.storage import Storage  # noqa: E402
+
+
+class FakeClock:
+    """Deterministic injectable time source.
+
+    Starts mid-morning local time so small advances stay within the
+    same day unless a test crosses midnight on purpose.
+    """
+
+    def __init__(self, start=None):
+        self.current = start or datetime(2026, 7, 4, 10, 0,
+                                         tzinfo=timezone.utc)
+
+    def now(self):
+        return self.current
+
+    def advance(self, **kwargs):
+        self.current += timedelta(**kwargs)
+        return self.current
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def storage(tmp_path):
+    store = Storage(str(tmp_path / "test.db"))
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def service(storage, clock):
+    return ReviewService(storage, ReviewScheduler(), now_fn=clock.now)
+
+
+@pytest.fixture
+def profile(storage):
+    return storage.ensure_default_profile("Testkid")
+
+
+def seed_card(storage, service, card_id, tags="", reps=0, due=None,
+              deck="Spanish", audio=None):
+    """Insert a card with review state. reps>0 + past due = review card;
+    reps=0 = new card."""
+    now = service.now()
+    state = service.scheduler.initial_state(card_id, now=due or now)
+    state["reps"] = reps
+    if due is not None:
+        state["due"] = iso(due)
+    storage.upsert_card(card_id, card_id, deck, f"front {card_id}",
+                        f"back {card_id}", tags,
+                        audio_filename=audio,
+                        audio_side="front" if audio else None,
+                        now_iso=iso(now))
+    storage.init_review_state(state)
+    storage.commit()
+    return card_id

--- a/cardbrick-py/tests/test_bury_suspend.py
+++ b/cardbrick-py/tests/test_bury_suspend.py
@@ -1,0 +1,61 @@
+"""Bury (until tomorrow) and suspend (indefinitely) queue exclusion."""
+
+from datetime import timedelta
+
+from conftest import seed_card
+
+
+def _queue_ids(service, **limits):
+    base = {"daily_new_cards": 100, "daily_review_cards": 100,
+            "session_card_limit": 100}
+    base.update(limits)
+    return [row["id"] for row in service.get_due_cards(limits=base)]
+
+
+def test_buried_card_disappears_until_tomorrow(storage, service, clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() - timedelta(days=1))
+    assert _queue_ids(service) == [1]
+
+    service.bury_card(1)
+    assert _queue_ids(service) == []
+
+    clock.advance(hours=2)  # later the same day: still buried
+    assert _queue_ids(service) == []
+
+    clock.advance(days=1)   # past local midnight: it comes back
+    assert _queue_ids(service) == [1]
+
+
+def test_bury_counts_in_session_row(storage, service, clock):
+    from cardbrick.scheduler import iso
+    seed_card(storage, service, 1)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.bury_card(1, session_id=session_id)
+    assert storage.session_row(session_id)["buried_count"] == 1
+
+
+def test_suspended_card_never_appears(storage, service, clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() - timedelta(days=1))
+    service.suspend_card(1)
+    assert _queue_ids(service) == []
+    clock.advance(days=30)
+    assert _queue_ids(service) == []
+
+
+def test_unsuspended_card_reappears_when_due(storage, service, clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() - timedelta(days=1))
+    service.suspend_card(1)
+    assert _queue_ids(service) == []
+    service.unsuspend_card(1)
+    assert _queue_ids(service) == [1]
+
+
+def test_suspended_cards_visible_to_parent(storage, service):
+    seed_card(storage, service, 1)
+    seed_card(storage, service, 2)
+    service.suspend_card(2)
+    suspended = storage.suspended_cards()
+    assert [c["id"] for c in suspended] == [2]

--- a/cardbrick-py/tests/test_filtering.py
+++ b/cardbrick-py/tests/test_filtering.py
@@ -1,0 +1,52 @@
+"""Tag/category filtering of the review queue."""
+
+from conftest import seed_card
+
+LIMITS = {"daily_new_cards": 100, "daily_review_cards": 100,
+          "session_card_limit": 100}
+
+
+def _ids(service, category_filter=None, profile=None):
+    return sorted(row["id"] for row in service.get_due_cards(
+        profile=profile, category_filter=category_filter, limits=LIMITS))
+
+
+def test_only_active_tags_appear(storage, service):
+    seed_card(storage, service, 1, tags="restaurant")
+    seed_card(storage, service, 2, tags="numbers")
+    seed_card(storage, service, 3, tags="restaurant greetings")
+    assert _ids(service, ["restaurant"]) == [1, 3]
+
+
+def test_untagged_cards_excluded_by_active_filter(storage, service):
+    seed_card(storage, service, 1, tags="")
+    seed_card(storage, service, 2, tags="food")
+    assert _ids(service, ["food"]) == [2]
+
+
+def test_no_filter_means_all_cards(storage, service):
+    seed_card(storage, service, 1, tags="")
+    seed_card(storage, service, 2, tags="food")
+    assert _ids(service, None) == [1, 2]
+
+
+def test_multi_category_group(storage, service):
+    seed_card(storage, service, 1, tags="restaurant")
+    seed_card(storage, service, 2, tags="numbers")
+    seed_card(storage, service, 3, tags="verbs")
+    assert _ids(service, ["restaurant", "numbers"]) == [1, 2]
+
+
+def test_parent_selected_categories_respected_via_profile(storage, service,
+                                                          profile):
+    seed_card(storage, service, 1, tags="travel")
+    seed_card(storage, service, 2, tags="grammar")
+    storage.update_profile(profile["id"], active_categories=["travel"])
+    profile = storage.get_profile(profile["id"])
+    assert _ids(service, profile=profile) == [1]
+
+
+def test_all_tags_surfaced_as_categories(storage, service):
+    seed_card(storage, service, 1, tags="restaurant food")
+    seed_card(storage, service, 2, tags="numbers")
+    assert storage.all_tags() == ["food", "numbers", "restaurant"]

--- a/cardbrick-py/tests/test_import.py
+++ b/cardbrick-py/tests/test_import.py
@@ -1,0 +1,151 @@
+"""Importer behaviour: basic notes, media, audio refs, safe degradation."""
+
+import json
+import os
+import sqlite3
+import zipfile
+
+import pytest
+
+from cardbrick.importer import ApkgError, import_apkg
+
+COL_SCHEMA = """
+CREATE TABLE col (
+    id INTEGER PRIMARY KEY, crt INTEGER, mod INTEGER, scm INTEGER,
+    ver INTEGER, dty INTEGER, usn INTEGER, ls INTEGER,
+    conf TEXT, models TEXT, decks TEXT, dconf TEXT, tags TEXT
+);
+CREATE TABLE notes (
+    id INTEGER PRIMARY KEY, guid TEXT, mid INTEGER, mod INTEGER,
+    usn INTEGER, tags TEXT, flds TEXT, sfld TEXT, csum INTEGER,
+    flags INTEGER, data TEXT
+);
+CREATE TABLE cards (
+    id INTEGER PRIMARY KEY, nid INTEGER, did INTEGER, ord INTEGER,
+    mod INTEGER, usn INTEGER, type INTEGER, queue INTEGER, due INTEGER,
+    ivl INTEGER, factor INTEGER, reps INTEGER, lapses INTEGER,
+    left INTEGER, odue INTEGER, odid INTEGER, flags INTEGER, data TEXT
+);
+"""
+
+BASIC, REVERSED, CLOZE = 1000, 1001, 1002
+MODELS = {
+    str(BASIC): {"id": BASIC, "name": "Basic", "type": 0,
+                 "tmpls": [{"ord": 0}]},
+    str(REVERSED): {"id": REVERSED, "name": "Basic (and reversed card)",
+                    "type": 0, "tmpls": [{"ord": 0}, {"ord": 1}]},
+    str(CLOZE): {"id": CLOZE, "name": "Cloze", "type": 1,
+                 "tmpls": [{"ord": 0}]},
+}
+DECKS = {"77": {"id": 77, "name": "Spanish"}}
+
+NOTES = [
+    # (note_id, model, fields, tags, n_cards)
+    (1, BASIC, ["¿Dónde está el baño?[sound:bano.mp3]",
+                "Where is the bathroom?"], "bathroom travel", 1),
+    (2, BASIC, ["<b>Hola</b><br>saludo", "Hello"], "greetings", 1),
+    (3, REVERSED, ["gato", "cat"], "animals", 2),
+    (4, CLOZE, ["El {{c1::perro}} ladra", ""], "animals", 1),
+    (5, BASIC, ["<style>p{}</style>", "<div></div>"], "", 1),  # empty
+]
+
+
+def build_apkg(path, collection_name="collection.anki2", media=True):
+    tmp_col = str(path) + ".col"
+    conn = sqlite3.connect(tmp_col)
+    conn.executescript(COL_SCHEMA)
+    conn.execute(
+        "INSERT INTO col VALUES (1, 0, 0, 0, 11, 0, 0, 0, '{}', ?, ?, "
+        "'{}', '{}')", (json.dumps(MODELS), json.dumps(DECKS)))
+    card_id = 1
+    for nid, mid, fields, tags, n_cards in NOTES:
+        conn.execute(
+            "INSERT INTO notes VALUES (?, ?, ?, 0, 0, ?, ?, ?, 0, 0, '')",
+            (nid, f"g{nid}", mid, f" {tags} ", "\x1f".join(fields),
+             fields[0]))
+        for ordinal in range(n_cards):
+            conn.execute(
+                "INSERT INTO cards VALUES (?, ?, 77, ?, 0, 0, 0, 0, 0, 0, "
+                "0, 0, 0, 0, 0, 0, 0, '')", (card_id, nid, ordinal))
+            card_id += 1
+    conn.commit()
+    conn.close()
+
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.write(tmp_col, collection_name)
+        if media:
+            zf.writestr("0", b"fake mp3 bytes")
+            zf.writestr("media", json.dumps({"0": "bano.mp3"}))
+    os.remove(tmp_col)
+
+
+@pytest.fixture
+def imported(tmp_path, storage, service):
+    apkg = tmp_path / "deck.apkg"
+    build_apkg(apkg)
+    media_dir = tmp_path / "media"
+    stats = import_apkg(str(apkg), storage, service.scheduler,
+                        str(media_dir))
+    return stats, media_dir
+
+
+def test_basic_apkg_imports_correctly(imported, storage):
+    stats, _ = imported
+    # 1 + 1 + 2 (reversed) importable; cloze + empty skipped.
+    assert stats.cards == 4
+    assert stats.decks == {"Spanish"}
+    cards = {row["id"]: row for row in
+             storage.conn.execute("SELECT * FROM cards")}
+    assert len(cards) == 4
+    # Reversed note produced both directions.
+    fronts = {row["front"] for row in cards.values()}
+    assert "gato" in fronts and "cat" in fronts
+    # HTML stripped.
+    assert any(row["front"].startswith("Hola") for row in cards.values())
+
+
+def test_sound_reference_detected(imported, storage):
+    row = storage.conn.execute(
+        "SELECT * FROM cards WHERE audio_filename IS NOT NULL").fetchone()
+    assert row["audio_filename"] == "bano.mp3"
+    assert row["audio_side"] == "front"
+    assert "[sound:" not in row["front"]
+
+
+def test_media_mapping_applied(imported):
+    stats, media_dir = imported
+    assert stats.media_files == 1
+    assert (media_dir / "bano.mp3").read_bytes() == b"fake mp3 bytes"
+
+
+def test_unsupported_cards_skipped_with_reasons(imported):
+    stats, _ = imported
+    assert stats.skipped_cards == 2
+    reasons = {reason for _cid, reason in stats.skipped}
+    assert "cloze note type" in reasons
+    assert "empty after HTML stripping" in reasons
+
+
+def test_tags_become_categories(imported, storage):
+    assert set(storage.all_tags()) == {"bathroom", "travel", "greetings",
+                                       "animals"}
+
+
+def test_reimport_preserves_review_progress(tmp_path, storage, service):
+    apkg = tmp_path / "deck.apkg"
+    build_apkg(apkg)
+    import_apkg(str(apkg), storage, service.scheduler, str(tmp_path / "m"))
+    service.answer_card(1, 3)
+    state = dict(storage.get_review_state(1))
+    import_apkg(str(apkg), storage, service.scheduler, str(tmp_path / "m"))
+    assert dict(storage.get_review_state(1)) == state
+
+
+def test_new_compressed_format_rejected_with_hint(tmp_path, storage,
+                                                  service):
+    apkg = tmp_path / "new.apkg"
+    with zipfile.ZipFile(apkg, "w") as zf:
+        zf.writestr("collection.anki21b", b"\x28\xb5\x2f\xfd")
+    with pytest.raises(ApkgError, match="Support older Anki versions"):
+        import_apkg(str(apkg), storage, service.scheduler,
+                    str(tmp_path / "m"))

--- a/cardbrick-py/tests/test_limits.py
+++ b/cardbrick-py/tests/test_limits.py
@@ -1,0 +1,105 @@
+"""Daily and session limit behaviour of the review queue."""
+
+from datetime import timedelta
+
+from conftest import seed_card
+
+
+def _limits(**overrides):
+    base = {"daily_new_cards": 10, "daily_review_cards": 40,
+            "session_card_limit": 50, "session_time_minutes": 15}
+    base.update(overrides)
+    return base
+
+
+def test_new_card_cap_is_respected(storage, service):
+    for i in range(1, 31):
+        seed_card(storage, service, i)
+    queue = service.get_due_cards(limits=_limits(daily_new_cards=10))
+    assert len(queue) == 10
+    assert all(row["reps"] == 0 for row in queue)
+
+
+def test_review_card_cap_is_respected(storage, service, clock):
+    past = clock.now() - timedelta(days=3)
+    for i in range(1, 61):
+        seed_card(storage, service, i, reps=1, due=past)
+    queue = service.get_due_cards(
+        limits=_limits(daily_review_cards=40, daily_new_cards=0,
+                       session_card_limit=100))
+    assert len(queue) == 40
+    assert all(row["reps"] > 0 for row in queue)
+
+
+def test_session_cap_trumps_daily_caps(storage, service, clock):
+    past = clock.now() - timedelta(days=1)
+    for i in range(1, 21):
+        seed_card(storage, service, i, reps=1, due=past)
+    for i in range(21, 41):
+        seed_card(storage, service, i)
+    queue = service.get_due_cards(
+        limits=_limits(daily_new_cards=20, daily_review_cards=20,
+                       session_card_limit=15))
+    assert len(queue) == 15
+
+
+def test_backlog_does_not_override_cap(storage, service, clock):
+    # A week of missed reviews: 500 due cards must not flood the child.
+    long_ago = clock.now() - timedelta(days=30)
+    for i in range(1, 501):
+        seed_card(storage, service, i, reps=2, due=long_ago)
+    queue = service.get_due_cards(limits=_limits())
+    assert len(queue) == 40  # daily_review_cards, not 500
+
+
+def test_reviews_come_before_new_cards(storage, service, clock):
+    seed_card(storage, service, 1)  # new
+    seed_card(storage, service, 2, reps=1,
+              due=clock.now() - timedelta(hours=2))
+    queue = service.get_due_cards(limits=_limits())
+    assert [row["id"] for row in queue] == [2, 1]
+
+
+def test_most_overdue_reviews_first(storage, service, clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() - timedelta(days=1))
+    seed_card(storage, service, 2, reps=1,
+              due=clock.now() - timedelta(days=5))
+    queue = service.get_due_cards(limits=_limits())
+    assert [row["id"] for row in queue] == [2, 1]
+
+
+def test_daily_cap_counts_work_already_done_today(storage, service, clock):
+    for i in range(1, 16):
+        seed_card(storage, service, i)
+    # Answer 6 new cards in a first sitting.
+    for row in service.get_due_cards(limits=_limits(daily_new_cards=6)):
+        service.answer_card(row["id"], 3)
+    # Second sitting the same day: only 4 new remain under a cap of 10.
+    queue = service.get_due_cards(limits=_limits(daily_new_cards=10))
+    new_ids = {row["id"] for row in queue if row["reps"] == 0}
+    assert len(new_ids) == 4
+
+
+def test_daily_caps_reset_at_local_midnight(storage, service, clock):
+    for i in range(1, 6):
+        seed_card(storage, service, i)
+    limits = _limits(daily_new_cards=5)
+    for row in service.get_due_cards(limits=limits):
+        service.answer_card(row["id"], 4)  # Easy: graduates, due days out
+    assert service.get_due_cards(limits=limits) == []
+
+    clock.advance(days=1)
+    for i in range(6, 11):
+        seed_card(storage, service, i)
+    queue = service.get_due_cards(limits=limits)
+    assert len(queue) == 5  # fresh allowance after rollover
+
+
+def test_profile_limits_are_used(storage, service, clock, profile):
+    storage.update_profile(profile["id"], daily_new_cards=3)
+    profile = storage.get_profile(profile["id"])
+    for i in range(1, 11):
+        seed_card(storage, service, i)
+    queue = service.get_due_cards(profile=profile)
+    assert len(queue) == 3

--- a/cardbrick-py/tests/test_persistence.py
+++ b/cardbrick-py/tests/test_persistence.py
@@ -1,0 +1,124 @@
+"""Durability: restarts, crash recovery, log consistency, migration."""
+
+import json
+import sqlite3
+
+from conftest import seed_card
+from cardbrick.scheduler import ReviewScheduler, iso
+from cardbrick.service import ReviewService
+from cardbrick.session import StudySession
+from cardbrick.storage import Storage
+
+
+def test_restart_preserves_review_state(tmp_path, clock):
+    db = str(tmp_path / "app.db")
+    storage = Storage(db)
+    service = ReviewService(storage, ReviewScheduler(), now_fn=clock.now)
+    seed_card(storage, service, 1)
+    service.answer_card(1, 3)
+    state = dict(storage.get_review_state(1))
+    storage.close()
+
+    reopened = Storage(db)
+    assert dict(reopened.get_review_state(1)) == state
+    reopened.close()
+
+
+def test_review_log_is_consistent_with_state(storage, service, clock):
+    seed_card(storage, service, 1)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.answer_card(1, 3, elapsed_ms=800, session_id=session_id)
+
+    entry = storage.conn.execute("SELECT * FROM review_log").fetchone()
+    logged_new = json.loads(entry["new_state_json"])
+    current = dict(storage.get_review_state(1))
+    # The logged new state matches what is stored (bar the audit stamp).
+    for key in ("due", "reps", "lapses", "state", "fsrs_json"):
+        assert logged_new[key] == current[key]
+    prev = json.loads(entry["previous_state_json"])
+    assert prev["reps"] == 0
+
+
+def test_interrupted_session_recovers_on_next_start(tmp_path, clock):
+    db = str(tmp_path / "app.db")
+    storage = Storage(db)
+    service = ReviewService(storage, ReviewScheduler(), now_fn=clock.now)
+    profile = storage.ensure_default_profile()
+    for i in range(1, 4):
+        seed_card(storage, service, i)
+    session = StudySession(storage, service, profile)
+    session.answer(4)  # Easy: graduates, no requeue
+    session_id = session.session_id
+    storage.close()  # simulated crash: no finish(), no ended_at
+
+    storage = Storage(db)
+    service = ReviewService(storage, ReviewScheduler(), now_fn=clock.now)
+    closed = storage.close_dangling_sessions(iso(clock.now()))
+    assert closed == [session_id]
+    row = storage.session_row(session_id)
+    assert row["ended_at"] is not None
+    assert row["cards_reviewed"] == 1  # completed review survived
+
+    # Daily accounting still reflects the interrupted work.
+    queue = service.get_due_cards(limits={"daily_new_cards": 3})
+    assert len(queue) == 2  # 1 of 3 new already used today
+    storage.close()
+
+
+def test_answer_is_durable_without_explicit_commit(tmp_path, clock):
+    """Auto-save after every answer: a second connection sees it."""
+    db = str(tmp_path / "app.db")
+    storage = Storage(db)
+    service = ReviewService(storage, ReviewScheduler(), now_fn=clock.now)
+    seed_card(storage, service, 1)
+    service.answer_card(1, 3)
+
+    other = sqlite3.connect(db)
+    reps = other.execute(
+        "SELECT reps FROM review_state WHERE card_id=1").fetchone()[0]
+    n_log = other.execute("SELECT COUNT(*) FROM review_log").fetchone()[0]
+    other.close()
+    storage.close()
+    assert reps == 1
+    assert n_log == 1
+
+
+def test_prototype_database_migrates_in_place(tmp_path):
+    """A DB created by the original prototype schema opens cleanly and
+    keeps its cards and progress."""
+    db = str(tmp_path / "old.db")
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE cards (
+            id INTEGER PRIMARY KEY, note_id INTEGER NOT NULL,
+            deck TEXT NOT NULL, front TEXT NOT NULL, back TEXT NOT NULL,
+            tags TEXT NOT NULL DEFAULT '', audio_filename TEXT,
+            audio_side TEXT
+        );
+        CREATE TABLE review_state (
+            card_id INTEGER PRIMARY KEY, due TEXT NOT NULL,
+            stability REAL, difficulty REAL,
+            elapsed_days INTEGER NOT NULL DEFAULT 0,
+            scheduled_days INTEGER NOT NULL DEFAULT 0,
+            reps INTEGER NOT NULL DEFAULT 0,
+            lapses INTEGER NOT NULL DEFAULT 0,
+            state INTEGER NOT NULL, fsrs_json TEXT NOT NULL
+        );
+    """)
+    conn.execute("INSERT INTO cards VALUES (1, 1, 'Spanish', 'hola', "
+                 "'hello', 'greetings', NULL, NULL)")
+    conn.execute("INSERT INTO review_state VALUES (1, "
+                 "'2026-01-01T00:00:00+00:00', 2.5, 5.0, 0, 0, 7, 1, 2, "
+                 "'{}')")
+    conn.commit()
+    conn.close()
+
+    storage = Storage(db)
+    card = storage.get_card(1)
+    assert card["front"] == "hola"
+    assert card["suspended"] == 0       # migrated column, default applied
+    assert card["reps"] == 7            # progress preserved
+    # New tables exist and work.
+    storage.ensure_default_profile()
+    assert storage.list_profiles()
+    storage.close()

--- a/cardbrick-py/tests/test_undo.py
+++ b/cardbrick-py/tests/test_undo.py
@@ -1,0 +1,97 @@
+"""Undo must be an exact rollback, never a guess."""
+
+from datetime import timedelta
+
+from conftest import seed_card
+from cardbrick.scheduler import iso
+from cardbrick.session import StudySession
+
+
+def _state_dict(storage, card_id):
+    return dict(storage.get_review_state(card_id))
+
+
+def test_answering_mutates_fsrs_state(storage, service):
+    seed_card(storage, service, 1)
+    before = _state_dict(storage, 1)
+    service.answer_card(1, 3)
+    after = _state_dict(storage, 1)
+    assert after["reps"] == before["reps"] + 1
+    assert after["due"] != before["due"]
+    assert after["fsrs_json"] != before["fsrs_json"]
+
+
+def test_undo_restores_exact_prior_state(storage, service, clock):
+    seed_card(storage, service, 1, reps=3,
+              due=clock.now() - timedelta(days=2))
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    before = _state_dict(storage, 1)
+
+    service.answer_card(1, 1, elapsed_ms=1500, session_id=session_id)
+    assert _state_dict(storage, 1) != before
+
+    assert service.undo_last_answer(session_id) == 1
+    assert _state_dict(storage, 1) == before
+
+
+def test_undo_marks_log_entry_undone(storage, service, clock):
+    seed_card(storage, service, 1)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.answer_card(1, 3, session_id=session_id)
+    service.undo_last_answer(session_id)
+
+    rows = storage.conn.execute("SELECT * FROM review_log").fetchall()
+    assert len(rows) == 1  # append-only: the entry stays, flagged
+    assert rows[0]["undone"] == 1
+    assert storage.last_review_log(session_id) is None
+
+
+def test_undo_with_empty_log_is_a_noop(storage, service, clock):
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    assert service.undo_last_answer(session_id) is None
+
+
+def test_undo_corrects_session_counters(storage, service, clock, profile):
+    for i in range(1, 4):
+        seed_card(storage, service, i)
+    session = StudySession(storage, service, profile)
+
+    session.answer(3, elapsed_ms=1000)   # card 1: Good
+    session.answer(1, elapsed_ms=1000)   # card 2: Again
+    counts = storage.session_counts(session.session_id)
+    assert counts["cards_reviewed"] == 2
+    assert counts["again_count"] == 1
+    assert counts["new_cards"] == 2
+
+    restored = session.undo()            # roll back the "Again"
+    assert restored["id"] == 2
+    counts = storage.session_counts(session.session_id)
+    assert counts["cards_reviewed"] == 1
+    assert counts["again_count"] == 0
+    assert counts["new_cards"] == 1
+    # The undone card is presented again immediately.
+    assert session.current_card()["id"] == 2
+
+
+def test_undo_corrects_daily_counts(storage, service, clock):
+    from cardbrick.service import local_day_start
+    seed_card(storage, service, 1)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.answer_card(1, 3, session_id=session_id)
+    day_start = iso(local_day_start(clock.now()))
+    assert storage.daily_counts(day_start)[0] == 1
+    service.undo_last_answer(session_id)
+    assert storage.daily_counts(day_start)[0] == 0
+
+
+def test_undo_only_rolls_back_most_recent(storage, service, clock):
+    seed_card(storage, service, 1)
+    seed_card(storage, service, 2)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.answer_card(1, 3, session_id=session_id)
+    after_first = _state_dict(storage, 1)
+    service.answer_card(2, 3, session_id=session_id)
+
+    assert service.undo_last_answer(session_id) == 2
+    assert _state_dict(storage, 1) == after_first  # card 1 untouched
+    assert service.undo_last_answer(session_id) == 1  # then card 1


### PR DESCRIPTION
Turn the proof-of-concept reviewer into a daily-use, child-safe study
appliance while keeping the original prototype (main.py review) intact.

New layers on top of the apkg -> SQLite -> py-fsrs -> pygame pipeline:

- storage.py: versioned schema that migrates prototype DBs in place;
  adds suspended/buried card flags, an append-only review_log with
  before/after state snapshots, sessions, and child_profiles.
- service.py: scheduler wrapper exposing get_due_cards / answer_card /
  undo_last_answer / bury_card / suspend_card with an injectable clock.
  Daily new/review caps are derived from the review log, so backlogs
  never flood the child and limits survive restarts; reviews queue
  before new cards; undo is an exact snapshot restore.
- session.py: one-sitting runner with session card/time limits,
  intra-session learning-step requeue, and a concise summary
  (counts, pass rate, time, buried/suspended).
- settings.py: JSON app settings with atomic writes.
- app.py: controller-first state-machine UI (child start -> review ->
  summary; parent mode with .apkg import, category selection from Anki
  tags, daily limits, suspended-card recovery, 7-day progress, and
  study-direction toggle). Auto-play + replay audio with missing-audio
  fallback; SCALED logical 640x480 canvas; spec button roles
  (A=Good B=Again X=Easy Y=Hard, L=replay, R=bury, SELECT=menu,
  START=finish).
- main.py: new default `study` command plus a `profile` command for
  CLI configuration; `review`, `import`, `decks` unchanged.
- importer.py: per-card skip reasons and card timestamps.
- tests/: 39 pytest cases covering daily limits (incl. backlog and
  midnight rollover with a fake clock), exact undo, bury/suspend, tag
  filtering, import, and crash/restart persistence.

Crash recovery: every answer commits log + state together; dangling
sessions are closed with aggregates on next boot.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X51wk4Xi1jmeu4Fddmsz3Y