### PR TITLE
Implement sprint-based microstudying with study-ahead fill

### DIFF
--- a/cardbrick-py/README.md
+++ b/cardbrick-py/README.md
@@ -99,8 +99,10 @@ python main.py study                  # add --fullscreen on the handheld
 
 # Configure the child profile from the command line (parent mode can do
 # the same on-device)
-python main.py profile --name Maya --daily-new 10 --daily-review 40 \
-    --session-cards 50 --session-minutes 15 --categories restaurant,food
+python main.py profile --name Maya --daily-goal 150 --daily-new 10 \
+    --sprint-cards 20 --sprint-minutes 10 --categories restaurant,food
+python main.py profile --study-ahead-days 2   # pull-forward horizon
+python main.py profile --study-ahead off      # day ends with the due pool
 python main.py profile --categories all      # study every tag
 
 # Legacy prototype reviewer (no limits/undo/profiles)
@@ -287,13 +289,26 @@ no undo button in the child-facing UI, so this is the one command in
 the app that discards data outright. This is an admin/CLI-only
 operation; it is deliberately not exposed in Parent Mode's on-device UI.
 
-### Daily limits
+### Daily goal & sprints (microstudying)
 
-Per child profile: `daily_new_cards` (default 10), `daily_review_cards`
-(40), `session_card_limit` (50), `session_time_minutes` (15, 0 = off).
-Limits count work already done today across restarts (derived from the
-review log), reviews are queued before new cards, and a backlog never
-floods the child — extra due cards simply wait for tomorrow.
+The day is a card goal chipped away in short sprints, not one sitting.
+Per child profile: `daily_goal_cards` (default 150) is the day's goal
+in card answers; each sprint is bounded by `session_card_limit`
+(default 20) and `session_time_minutes` (10, 0 = off), so the child
+always knows how many sprints they still owe ("3 sprints to go today").
+Doing sprints back-to-back — "going ahead" — burns the count down just
+the same as spacing them out; the schedule is the child's own and
+nothing nags. `daily_new_cards` (default 10) still paces how fast new
+material enters FSRS.
+
+When today's due cards run out before the goal, sprints top up with
+soon-due cards pulled forward (`study_ahead_days`, default 1 — safe
+under FSRS, an early review just earns a smaller stability gain), and
+after the goal is met an optional bonus sprint is offered. Set
+`study_ahead_enabled` to 0 to end the day when the due pool is empty
+instead. All counters are derived from the review log, so they survive
+restarts and undo; a backlog never floods the child — extra due cards
+arrive one sprint at a time.
 
 ### Durability
 

--- a/cardbrick-py/cardbrick/app.py
+++ b/cardbrick-py/cardbrick/app.py
@@ -1,10 +1,13 @@
 """CardBrick-style study appliance UI.
 
-A state-driven pygame app aimed at children doing a short daily Spanish
-session on a handheld. Screens:
+A state-driven pygame app aimed at children microstudying Spanish on a
+handheld: a daily card goal chipped away in short sprints across the
+day (see ReviewService.sprint_status), never one long sitting. Screens:
 
     ChildStart -> DeckSelect (only when >1 deck is assigned)
-              -> Review (question/answer) -> SessionSummary -> ChildStart
+              -> Review (one sprint) -> SessionSummary
+                 -> Review again ("going ahead": the next sprint now)
+                 -> or back to ChildStart
     ChildStart / SessionSummary -> Calendar (stamp calendar) -> back
     ChildStart -> ParentMode (import / decks / categories / limits /
                               suspended / progress / calendar /
@@ -156,6 +159,8 @@ class CardBrickApp:
         self.input_map = InputMap(paths.input_map_path if paths else None)
         self._image_cache = {}  # vocab card images, decoded once per file
         self._session_deck_filter = None  # child's per-sitting deck pick
+        self._session_bonus = False  # next sprint ignores the daily goal
+        self._sprint_label = ""      # "Sprint 3/8" shown in the review header
         self._calendar_return = "CHILD_START"  # where the stamp calendar exits to
         self.input = InputTranslator(self.input_map)
 
@@ -340,8 +345,8 @@ class CardBrickApp:
 
     def screen_child_start(self):
         self._session_deck_filter = None  # cleared each time we land here
-        review_n, new_n = self.service.counts_for_queue(profile=self.profile)
-        total = review_n + new_n
+        self._session_bonus = False
+        status = self.service.sprint_status(profile=self.profile)
         available_decks = self._resolve_available_decks()
         categories = self.profile["active_categories"]
         cat_label = "All categories" if categories is None else \
@@ -349,6 +354,8 @@ class CardBrickApp:
         decks = self.profile["active_decks"]
         deck_label = "All decks" if decks is None else \
             ", ".join(decks) if decks else "No decks set"
+        startable = status["next_sprint_cards"] > 0
+        bonus = not startable and status["bonus_cards"] > 0
 
         while True:
             action = self.poll()
@@ -359,7 +366,9 @@ class CardBrickApp:
             if action == "north_button":
                 self._calendar_return = "CHILD_START"
                 return "CALENDAR"
-            if action in ("south_button", "unmapped") and total > 0:
+            if action in ("south_button", "unmapped") and \
+                    (startable or bonus):
+                self._session_bonus = bonus
                 return "DECK_SELECT" if len(available_decks) > 1 \
                     else "REVIEW"
 
@@ -370,26 +379,45 @@ class CardBrickApp:
                                               FG), 80)
             self._center(self.font.render(cat_label, True, ACCENT), 150)
             self._center(self.font_small.render(deck_label, True, DIM), 182)
-            if total > 0:
-                due_text = f"{total} cards today"
-                detail = f"{review_n} to review  +  {new_n} new"
-                self._center(self.font_big.render(due_text, True, FG), 215)
-                self._center(self.font.render(detail, True, DIM), 265)
-                limit_line = (f"up to {self.profile['session_card_limit']} "
-                              f"cards / "
-                              f"{self.profile['session_time_minutes']} min")
-                self._center(self.font_small.render(limit_line, True, DIM),
+            if startable:
+                n = status["sprints_remaining"]
+                headline = "Last sprint of the day!" if n == 1 else \
+                    f"{n} sprints to go today"
+                self._center(self.font_big.render(headline, True, FG), 215)
+                self._center(self.font.render(
+                    f"{status['cards_done']} / {status['goal']} cards done",
+                    True, DIM), 265)
+                minutes = self.profile["session_time_minutes"]
+                sprint_line = (f"next sprint: "
+                               f"{status['next_sprint_cards']} cards"
+                               + (f" / about {minutes} min" if minutes
+                                  else ""))
+                self._center(self.font_small.render(sprint_line, True, DIM),
                              305)
                 self._center(self.font.render(
                     "Press the bottom button to start!", True, GOOD), 360)
+            elif bonus:
+                self._center(self.font_big.render("Goal reached! Great job!",
+                                                  True, GOOD), 215)
+                self._center(self.font.render(
+                    f"{status['cards_done']} cards today — all "
+                    f"{status['sprints_planned']} sprints done", True, DIM),
+                    265)
+                self._center(self.font_small.render(
+                    f"Spare time? A bonus sprint of "
+                    f"{status['bonus_cards']} cards is ready.", True, DIM),
+                    305)
+                self._center(self.font.render(
+                    "Bottom button = bonus sprint (totally optional!)",
+                    True, GOOD), 360)
             else:
                 self._center(self.font_big.render("All done for today!",
                                                   True, GOOD), 230)
                 self._center(self.font.render("Come back tomorrow.", True,
                                               DIM), 285)
             self._footer(
-                "Bottom = Start    Top = Calendar" if total else
-                "Top = Calendar",
+                "Bottom = Start    Top = Calendar" if (startable or bonus)
+                else "Top = Calendar",
                 "SELECT = Parent    START = Quit")
             self.present()
             self.clock.tick(FPS)
@@ -407,7 +435,8 @@ class CardBrickApp:
         # screen redraws every tick like the other menus, and querying
         # the DB per entry per frame would not be free on a big deck.
         counts = [self.service.counts_for_queue(profile=self.profile,
-                                                deck_filter=decks)
+                                                deck_filter=decks,
+                                                bonus=self._session_bonus)
                  for _label, decks in entries]
         index = 0
 
@@ -455,11 +484,20 @@ class CardBrickApp:
     VOCAB_PHASE_RATING = {0: 4, 1: 3, 2: 2, 3: 1}  # Easy, Good, Hard, Again
 
     def screen_review(self):
+        if self._session_bonus:
+            self._sprint_label = "Bonus sprint"
+        else:
+            status = self.service.sprint_status(profile=self.profile)
+            number = min(status["sprints_planned"] -
+                         status["sprints_remaining"] + 1,
+                         status["sprints_planned"])
+            self._sprint_label = f"Sprint {number}/{status['sprints_planned']}"
         session = StudySession(self.storage, self.service, self.profile,
-                               deck_filter=self._session_deck_filter)
-        log.info("session %d started: %d cards queued (deck filter: %s)",
+                               deck_filter=self._session_deck_filter,
+                               bonus=self._session_bonus)
+        log.info("session %d started: %d cards queued (%s, deck filter: %s)",
                  session.session_id, session.planned_total,
-                 self._session_deck_filter)
+                 self._sprint_label, self._session_deck_filter)
         try:
             return self._review_loop(session)
         finally:
@@ -644,7 +682,8 @@ class CardBrickApp:
         if card["tags"]:
             header += "  ·  " + " ".join(card["tags"].split()[:3])
         self.screen.blit(self.font_small.render(header, True, DIM), (16, 12))
-        left = f"{session.remaining()} left"
+        left = f"{self._sprint_label}  ·  {session.remaining()} left" \
+            if self._sprint_label else f"{session.remaining()} left"
         surf = self.font_small.render(left, True, DIM)
         self.screen.blit(surf, (self.w - surf.get_width() - 16, 12))
         pygame.draw.line(self.screen, DIVIDER, (16, 40), (self.w - 16, 40))
@@ -833,6 +872,27 @@ class CardBrickApp:
         pass_rate = s.get("pass_rate")
         avg = s.get("avg_response_ms")
 
+        # Where the day stands now that this sprint is in the log; the
+        # deck filter is kept so "next sprint now" continues the same
+        # deck the child picked for this sitting.
+        status = self.service.sprint_status(
+            profile=self.profile, deck_filter=self._session_deck_filter)
+        more = status["next_sprint_cards"] > 0
+        bonus = not more and status["bonus_cards"] > 0
+        goal_met = status["cards_remaining"] == 0
+
+        if goal_met:
+            headline = "Goal reached! Great job!"
+            subtitle = f"{status['cards_done']} CARDS TODAY"
+        elif more:
+            n = status["sprints_remaining"]
+            headline = "¡Buen trabajo!"
+            subtitle = "SPRINT DONE — LAST ONE TO GO" if n == 1 else \
+                f"SPRINT DONE — {n} TO GO TODAY"
+        else:
+            headline = "¡Buen trabajo!"
+            subtitle = "SPRINT DONE — NO MORE CARDS TODAY"
+
         lines = [
             (f"Cards answered:  {s.get('cards_reviewed', 0)}", FG),
             (f"New cards:  {s.get('new_cards', 0)}    "
@@ -845,10 +905,19 @@ class CardBrickApp:
              else "Pass rate:  —", DIM),
             (f"Time:  {minutes}m {seconds:02d}s" +
              (f"    Avg answer:  {avg / 1000:.1f}s" if avg else ""), DIM),
+            (f"Today:  {status['cards_done']} / {status['goal']} cards",
+             DIM),
         ]
         if s.get("buried_count") or s.get("suspended_count"):
             lines.append((f"Buried {s.get('buried_count', 0)}   "
                           f"Suspended {s.get('suspended_count', 0)}", DIM))
+
+        if more:
+            go_label = "Bottom = Next sprint now    Right = Done for now"
+        elif bonus:
+            go_label = "Bottom = Bonus sprint    Right = Done for now"
+        else:
+            go_label = "Bottom = Done"
 
         while True:
             action = self.poll()
@@ -857,21 +926,24 @@ class CardBrickApp:
             if action == "north_button":
                 self._calendar_return = "CHILD_START"
                 return "CALENDAR"
-            if action in ("south_button", "east_button", "unmapped",
-                          "select"):
+            if action in ("south_button", "unmapped"):
+                # "Going ahead": roll straight into the next sprint —
+                # spare time now means fewer sprints owed later.
+                if more or bonus:
+                    self._session_bonus = bonus
+                    return "REVIEW"
+                return "CHILD_START"
+            if action in ("east_button", "select"):
                 return "CHILD_START"
 
             self.screen.fill(BG)
-            self._center(self.font_big.render("¡Buen trabajo!", True, GOOD),
-                         56)
-            self._center(self.font_small.render("SESSION COMPLETE", True,
-                                                DIM), 108)
+            self._center(self.font_big.render(headline, True, GOOD), 56)
+            self._center(self.font_small.render(subtitle, True, DIM), 108)
             y = 160
             for text, color in lines:
                 self._center(self.font.render(text, True, color), y)
                 y += 44
-            self._footer("Bottom = Done    Top = Calendar",
-                         "START = Quit")
+            self._footer(go_label, "Top = Calendar   START = Quit")
             self.present()
             self.clock.tick(FPS)
 
@@ -986,7 +1058,7 @@ class CardBrickApp:
             ("Import deck (.apkg)", "PARENT_IMPORT"),
             ("Decks", "PARENT_DECKS"),
             ("Categories", "PARENT_CATEGORIES"),
-            ("Daily limits", "PARENT_LIMITS"),
+            ("Daily goal & sprints", "PARENT_LIMITS"),
             ("Suspended cards", "PARENT_SUSPENDED"),
             ("Progress", "PARENT_PROGRESS"),
             ("Calendar (stamps)", "CALENDAR"),
@@ -1197,11 +1269,14 @@ class CardBrickApp:
             self.clock.tick(FPS)
 
     def screen_parent_limits(self):
+        # The goal/sprint pair defines the child's day: goal cards split
+        # into sprints of session_card_limit. daily_new_cards paces new
+        # material; study-ahead settings are CLI-only for now.
         fields = [
+            ("Daily goal (cards)", "daily_goal_cards", 10, 500),
             ("New cards per day", "daily_new_cards", 0, 100),
-            ("Review cards per day", "daily_review_cards", 0, 300),
-            ("Cards per session", "session_card_limit", 1, 200),
-            ("Minutes per session (0 = off)", "session_time_minutes", 0, 90),
+            ("Cards per sprint", "session_card_limit", 1, 200),
+            ("Minutes per sprint (0 = off)", "session_time_minutes", 0, 90),
         ]
         values = {key: self.profile[key] for _, key, _, _ in fields}
         index = 0
@@ -1215,13 +1290,20 @@ class CardBrickApp:
                 index = (index - 1) % len(fields)
             elif action == "dpad_down":
                 index = (index + 1) % len(fields)
-            elif action in ("dpad_left", "dpad_right"):
+            elif action in ("dpad_left", "dpad_right", "l1", "r1"):
                 label, key, lo, hi = fields[index]
-                step = -1 if action == "dpad_left" else 1
+                step = {"dpad_left": -1, "dpad_right": 1,
+                        "l1": -10, "r1": 10}[action]
                 values[key] = min(max(values[key] + step, lo), hi)
 
             self.screen.fill(BG)
-            self._center(self.font_big.render("Daily Limits", True, FG), 40)
+            self._center(self.font_big.render("Daily Goal & Sprints", True,
+                                              FG), 40)
+            sprint_size = max(values["session_card_limit"], 1)
+            sprints = -(-values["daily_goal_cards"] // sprint_size)
+            self._center(self.font_small.render(
+                f"= {sprints} sprint{'s' if sprints != 1 else ''} a day",
+                True, DIM), 92)
             y = 140
             for i, (label, key, _, _) in enumerate(fields):
                 color = ACCENT if i == index else FG
@@ -1231,7 +1313,8 @@ class CardBrickApp:
                 value = self.font.render(str(values[key]), True, color)
                 self.screen.blit(value, (self.w - 120, y))
                 y += 52
-            self._footer("Left/Right = Adjust   Right btn = Save & back")
+            self._footer("Left/Right = Adjust   L1/R1 = ±10   "
+                         "Right btn = Save & back")
             self.present()
             self.clock.tick(FPS)
 

--- a/cardbrick-py/cardbrick/service.py
+++ b/cardbrick-py/cardbrick/service.py
@@ -6,10 +6,16 @@ and scheduler.py (the py-fsrs wrapper) into the operations the spec
 names:
 
     get_due_cards(profile, category_filter, limits)
+    sprint_status(profile)
     answer_card(card_id, rating, elapsed_ms)
     undo_last_answer()
     bury_card(card_id)
     suspend_card(card_id)
+
+The study day is modelled as a card goal (``daily_goal_cards``) chipped
+away in short sprints — microstudying — rather than one sitting;
+get_due_cards builds one sprint's queue and sprint_status reports how
+many sprints are left.
 
 Time is injected (``now_fn``) so daily-rollover behaviour is testable.
 All daily accounting is derived from the append-only review log rather
@@ -29,9 +35,11 @@ LEARN_AHEAD = timedelta(minutes=20)
 
 DEFAULT_LIMITS = {
     "daily_new_cards": 10,
-    "daily_review_cards": 40,
-    "session_card_limit": 50,
-    "session_time_minutes": 15,
+    "daily_goal_cards": 150,
+    "session_card_limit": 20,
+    "session_time_minutes": 10,
+    "study_ahead_days": 1,
+    "study_ahead_enabled": 1,
 }
 
 
@@ -72,13 +80,25 @@ class ReviewService:
     # -- queue building --------------------------------------------------------
 
     def get_due_cards(self, profile=None, category_filter=None,
-                      deck_filter=None, limits=None):
-        """Build the capped review queue for a study session.
+                      deck_filter=None, limits=None, bonus=False):
+        """Build the queue for one sprint.
 
-        Order: due review cards (most overdue first), then new cards.
-        Suspended and buried cards never appear. Daily caps subtract
-        work already logged today, so a backlog can never flood a child
-        and restarting mid-day continues from where the day left off.
+        The day is a card goal (``daily_goal_cards`` answers) chipped
+        away in short sprints; each call returns the next sprint's
+        worth, at most ``session_card_limit`` cards and never more than
+        what's left of the goal. Order: due review cards (most overdue
+        first), then new cards (paced by ``daily_new_cards``), then —
+        when those can't fill the sprint — soon-due cards pulled
+        forward ("studying ahead", within ``study_ahead_days``), so a
+        child with spare time never hits a dead end mid-goal. Suspended
+        and buried cards never appear. All budgets subtract work
+        already logged today, so restarting mid-day continues from
+        where the day left off.
+
+        ``bonus=True`` ignores the goal budget: used for the optional
+        bonus sprint offered after the goal is met. It's an offer, not
+        an obligation — nothing in the queue math ever *requires* more
+        studying.
 
         ``category_filter``/``deck_filter`` of None fall back to the
         profile's ``active_categories``/``active_decks``; an explicit
@@ -98,37 +118,95 @@ class ReviewService:
                 deck_filter = profile.get("active_decks")
 
         now = self.now()
-        new_done, review_done, _ = self.storage.daily_counts(
-            iso(local_day_start(now)))
+        day_start = iso(local_day_start(now))
+        new_done, _review_done, _ = self.storage.daily_counts(day_start)
+        answers_done = self.storage.daily_answer_count(day_start)
         remaining_new = max(limits["daily_new_cards"] - new_done, 0)
-        remaining_review = max(
-            limits["daily_review_cards"] - review_done, 0)
+        goal_left = max(limits["daily_goal_cards"] - answers_done, 0)
+        budget = limits["session_card_limit"] if bonus \
+            else min(goal_left, limits["session_card_limit"])
 
         queue = []
         for row in self.storage.queue_candidates(iso(now), new_cards=False,
                                                  decks=deck_filter):
-            if remaining_review <= 0:
+            if len(queue) >= budget:
                 break
             if card_matches_categories(row["tags"], category_filter):
                 queue.append(row)
-                remaining_review -= 1
         for row in self.storage.queue_candidates(iso(now), new_cards=True,
                                                  decks=deck_filter):
-            if remaining_new <= 0:
+            if remaining_new <= 0 or len(queue) >= budget:
                 break
             if card_matches_categories(row["tags"], category_filter):
                 queue.append(row)
                 remaining_new -= 1
+        if limits["study_ahead_enabled"] and len(queue) < budget:
+            horizon = next_local_midnight(now) + timedelta(
+                days=limits["study_ahead_days"])
+            for row in self.storage.ahead_candidates(iso(now), iso(horizon),
+                                                     decks=deck_filter):
+                if len(queue) >= budget:
+                    break
+                if card_matches_categories(row["tags"], category_filter):
+                    queue.append(row)
 
-        return queue[:limits["session_card_limit"]]
+        return queue
 
     def counts_for_queue(self, profile=None, category_filter=None,
-                         deck_filter=None, limits=None):
+                         deck_filter=None, limits=None, bonus=False):
         """(review, new) counts of what get_due_cards would return."""
         queue = self.get_due_cards(profile, category_filter, deck_filter,
-                                   limits)
+                                   limits, bonus=bonus)
         new = sum(1 for row in queue if row["reps"] == 0)
         return len(queue) - new, new
+
+    def sprint_status(self, profile=None, category_filter=None,
+                      deck_filter=None, limits=None):
+        """Where the day stands, in sprints.
+
+        The daily goal is meant to be chipped away in short sprints
+        spread across the day, but the schedule is the child's own:
+        doing sprints back-to-back ("going ahead") decrements
+        ``sprints_remaining`` exactly the same as spacing them out.
+        Everything is derived from the review log, so the numbers
+        survive restarts, crashes, and undo.
+
+        Returns a dict:
+            cards_done         answers logged today
+            goal               daily_goal_cards in effect
+            cards_remaining    what's left of the goal
+            sprints_planned    ceil(goal / sprint size)
+            sprints_remaining  ceil(cards_remaining / sprint size)
+            next_sprint_cards  size of the queue the next sprint gets
+            bonus_cards        when nothing is queued: size of the
+                               optional goal-ignoring bonus sprint
+                               (0 otherwise)
+        """
+        limits = dict(DEFAULT_LIMITS, **(limits or {}))
+        if profile:
+            for key in DEFAULT_LIMITS:
+                if profile.get(key) is not None:
+                    limits[key] = profile[key]
+        now = self.now()
+        done = self.storage.daily_answer_count(iso(local_day_start(now)))
+        goal = limits["daily_goal_cards"]
+        sprint_size = max(limits["session_card_limit"], 1)
+        remaining = max(goal - done, 0)
+        next_sprint = len(self.get_due_cards(profile, category_filter,
+                                             deck_filter, limits))
+        bonus = 0
+        if next_sprint == 0:
+            bonus = len(self.get_due_cards(profile, category_filter,
+                                           deck_filter, limits, bonus=True))
+        return {
+            "cards_done": done,
+            "goal": goal,
+            "cards_remaining": remaining,
+            "sprints_planned": -(-goal // sprint_size),
+            "sprints_remaining": -(-remaining // sprint_size),
+            "next_sprint_cards": next_sprint,
+            "bonus_cards": bonus,
+        }
 
     # -- answering ---------------------------------------------------------------
 

--- a/cardbrick-py/cardbrick/session.py
+++ b/cardbrick-py/cardbrick/session.py
@@ -14,12 +14,19 @@ from .scheduler import iso
 
 
 class StudySession:
-    def __init__(self, storage, service, profile, deck_filter=None):
-        """``deck_filter`` overrides the profile's assigned decks for
+    def __init__(self, storage, service, profile, deck_filter=None,
+                 bonus=False):
+        """One sprint: the unit of microstudying (see
+        ReviewService.sprint_status).
+
+        ``deck_filter`` overrides the profile's assigned decks for
         just this sitting — e.g. a child picking one specific deck out
         of several the parent has assigned (see app.py's DECK_SELECT
         screen). None falls back to the profile's active_decks, same
-        convention as ReviewService.get_due_cards."""
+        convention as ReviewService.get_due_cards.
+
+        ``bonus`` marks the optional goal-ignoring sprint offered after
+        the daily goal is met; the queue is built accordingly."""
         self.storage = storage
         self.service = service
         self.profile = profile
@@ -30,7 +37,8 @@ class StudySession:
             category_filter=profile.get("active_categories"))
 
         rows = service.get_due_cards(profile=profile,
-                                     deck_filter=deck_filter)
+                                     deck_filter=deck_filter,
+                                     bonus=bonus)
         self.queue = deque(row["id"] for row in rows)
         self.planned_total = len(rows)
         self.finished = False

--- a/cardbrick-py/cardbrick/storage.py
+++ b/cardbrick-py/cardbrick/storage.py
@@ -18,7 +18,7 @@ import sqlite3
 
 log = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -110,9 +110,12 @@ CREATE TABLE IF NOT EXISTS child_profiles (
     active_decks         TEXT,
     daily_new_cards      INTEGER NOT NULL DEFAULT 10,
     daily_review_cards   INTEGER NOT NULL DEFAULT 40,
-    session_card_limit   INTEGER NOT NULL DEFAULT 50,
-    session_time_minutes INTEGER NOT NULL DEFAULT 15,
-    study_direction      TEXT NOT NULL DEFAULT 'normal'
+    daily_goal_cards     INTEGER NOT NULL DEFAULT 150,
+    session_card_limit   INTEGER NOT NULL DEFAULT 20,
+    session_time_minutes INTEGER NOT NULL DEFAULT 10,
+    study_direction      TEXT NOT NULL DEFAULT 'normal',
+    study_ahead_days     INTEGER NOT NULL DEFAULT 1,
+    study_ahead_enabled  INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE INDEX IF NOT EXISTS idx_cards_deck ON cards(deck);
@@ -135,6 +138,9 @@ _STATE_UPGRADES = {
 }
 _PROFILE_UPGRADES = {
     "active_decks": "TEXT",
+    "daily_goal_cards": "INTEGER NOT NULL DEFAULT 150",
+    "study_ahead_days": "INTEGER NOT NULL DEFAULT 1",
+    "study_ahead_enabled": "INTEGER NOT NULL DEFAULT 1",
 }
 
 
@@ -178,7 +184,14 @@ class Storage:
             self._backup(stored)
         self._upgrade_table("cards", _CARD_UPGRADES)
         self._upgrade_table("review_state", _STATE_UPGRADES)
-        self._upgrade_table("child_profiles", _PROFILE_UPGRADES)
+        added = self._upgrade_table("child_profiles", _PROFILE_UPGRADES)
+        if "daily_goal_cards" in added:
+            # Existing profiles were tuned around the old review+new caps;
+            # seed the goal from them so nobody's day suddenly triples.
+            self.conn.execute(
+                """UPDATE child_profiles
+                   SET daily_goal_cards = daily_new_cards +
+                                          daily_review_cards""")
         self.conn.executescript(SCHEMA)
         self.conn.execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES "
@@ -203,17 +216,21 @@ class Storage:
                         exc)
 
     def _upgrade_table(self, table, upgrades):
+        """ALTER TABLE in any missing columns; returns the ones added."""
         row = self.conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
             (table,)).fetchone()
         if row is None:
-            return
+            return []
         existing = {r["name"] for r in
                     self.conn.execute(f"PRAGMA table_info({table})")}
+        added = []
         for column, decl in upgrades.items():
             if column not in existing:
                 self.conn.execute(
                     f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+                added.append(column)
+        return added
 
     def close(self):
         self.conn.close()
@@ -339,6 +356,30 @@ class Storage:
             query = base + " AND r.reps > 0 AND r.due <= :now ORDER BY r.due"
         return self.conn.execute(query, params).fetchall()
 
+    def ahead_candidates(self, now_iso, horizon_iso, decks=None):
+        """Cards due after now but within the study-ahead horizon.
+
+        Same eligibility rules as queue_candidates (no suspended cards,
+        no buried cards, optional deck restriction), ordered soonest-due
+        first so the most urgent cards are pulled forward first. Used to
+        top up a sprint when today's due pool runs dry.
+        """
+        if decks is not None and len(decks) == 0:
+            return []  # explicitly "no decks active": nothing to pull
+        query = """SELECT c.*, r.due, r.reps, r.lapses,
+                          r.state AS fsrs_state, r.fsrs_json
+                   FROM cards c JOIN review_state r ON r.card_id = c.id
+                   WHERE c.suspended = 0
+                     AND (c.buried_until IS NULL OR c.buried_until <= :now)
+                     AND r.reps > 0 AND r.due > :now AND r.due <= :horizon"""
+        params = {"now": now_iso, "horizon": horizon_iso}
+        if decks is not None:
+            placeholders = ",".join(f":deck{i}" for i in range(len(decks)))
+            query += f" AND c.deck IN ({placeholders})"
+            params.update({f"deck{i}": name for i, name in enumerate(decks)})
+        query += " ORDER BY r.due"
+        return self.conn.execute(query, params).fetchall()
+
     def suspended_cards(self):
         return self.conn.execute(
             "SELECT * FROM cards WHERE suspended = 1 ORDER BY deck, id"
@@ -430,6 +471,18 @@ class Storage:
                WHERE undone = 0 AND reviewed_at >= ?""",
             (day_start_iso,))}
         return len(new_ids), len(all_ids - new_ids), new_ids
+
+    def daily_answer_count(self, day_start_iso):
+        """Total not-undone answers logged since the local day start.
+
+        Unlike daily_counts this counts every answer — including
+        learning-step repeats of the same card — which is the unit of
+        the daily goal ("150 cards a day").
+        """
+        return self.conn.execute(
+            """SELECT COUNT(*) AS n FROM review_log
+               WHERE undone = 0 AND reviewed_at >= ?""",
+            (day_start_iso,)).fetchone()["n"]
 
     def daily_history(self, since_iso):
         """Raw (reviewed_at, was_new, card_id) tuples for progress views."""
@@ -536,8 +589,10 @@ class Storage:
 
     def create_profile(self, name, **fields):
         allowed = {"active_categories", "active_decks", "daily_new_cards",
-                   "daily_review_cards", "session_card_limit",
-                   "session_time_minutes", "study_direction"}
+                   "daily_review_cards", "daily_goal_cards",
+                   "session_card_limit", "session_time_minutes",
+                   "study_direction", "study_ahead_days",
+                   "study_ahead_enabled"}
         unknown = set(fields) - allowed
         if unknown:
             raise ValueError(f"Unknown profile fields: {unknown}")
@@ -553,8 +608,9 @@ class Storage:
     def update_profile(self, profile_id, **fields):
         allowed = {"name", "active_categories", "active_decks",
                    "daily_new_cards", "daily_review_cards",
-                   "session_card_limit", "session_time_minutes",
-                   "study_direction"}
+                   "daily_goal_cards", "session_card_limit",
+                   "session_time_minutes", "study_direction",
+                   "study_ahead_days", "study_ahead_enabled"}
         unknown = set(fields) - allowed
         if unknown:
             raise ValueError(f"Unknown profile fields: {unknown}")

--- a/cardbrick-py/main.py
+++ b/cardbrick-py/main.py
@@ -82,14 +82,23 @@ def build_parser():
     p_profile = sub.add_parser("profile",
                                help="View or edit the child profile")
     p_profile.add_argument("--name", help="Child's name")
+    p_profile.add_argument("--daily-goal", type=int,
+                           help="Daily goal in card answers; done in "
+                                "sprints of --sprint-cards")
     p_profile.add_argument("--daily-new", type=int,
                            help="New cards per day")
-    p_profile.add_argument("--daily-review", type=int,
-                           help="Review cards per day")
-    p_profile.add_argument("--session-cards", type=int,
-                           help="Max cards per session")
-    p_profile.add_argument("--session-minutes", type=int,
-                           help="Max minutes per session (0 = no limit)")
+    p_profile.add_argument("--sprint-cards", "--session-cards", type=int,
+                           dest="sprint_cards",
+                           help="Max cards per sprint")
+    p_profile.add_argument("--sprint-minutes", "--session-minutes",
+                           type=int, dest="sprint_minutes",
+                           help="Max minutes per sprint (0 = no limit)")
+    p_profile.add_argument("--study-ahead-days", type=int,
+                           help="How many days ahead a sprint may pull "
+                                "soon-due cards from (default 1)")
+    p_profile.add_argument("--study-ahead", choices=["on", "off"],
+                           help="Allow filling sprints with soon-due "
+                                "cards and offering bonus sprints")
     p_profile.add_argument("--categories",
                            help="Comma-separated active categories, "
                                 "or 'all' for every tag")
@@ -249,14 +258,19 @@ def _profile_command(storage, args):
     updates = {}
     if args.name:
         updates["name"] = args.name
+    if args.daily_goal is not None:
+        updates["daily_goal_cards"] = args.daily_goal
     if args.daily_new is not None:
         updates["daily_new_cards"] = args.daily_new
-    if args.daily_review is not None:
-        updates["daily_review_cards"] = args.daily_review
-    if args.session_cards is not None:
-        updates["session_card_limit"] = args.session_cards
-    if args.session_minutes is not None:
-        updates["session_time_minutes"] = args.session_minutes
+    if args.sprint_cards is not None:
+        updates["session_card_limit"] = args.sprint_cards
+    if args.sprint_minutes is not None:
+        updates["session_time_minutes"] = args.sprint_minutes
+    if args.study_ahead_days is not None:
+        updates["study_ahead_days"] = args.study_ahead_days
+    if args.study_ahead:
+        updates["study_ahead_enabled"] = 1 if args.study_ahead == "on" \
+            else 0
     if args.direction:
         updates["study_direction"] = args.direction
     if args.categories:

--- a/cardbrick-py/tests/test_limits.py
+++ b/cardbrick-py/tests/test_limits.py
@@ -1,4 +1,8 @@
-"""Daily and session limit behaviour of the review queue."""
+"""Daily-goal, new-card, and sprint-size behaviour of the review queue.
+
+Study-ahead fill is disabled in these limits so each budget can be
+tested in isolation; test_study_ahead.py covers the fill behaviour.
+"""
 
 from datetime import timedelta
 
@@ -6,8 +10,9 @@ from conftest import seed_card
 
 
 def _limits(**overrides):
-    base = {"daily_new_cards": 10, "daily_review_cards": 40,
-            "session_card_limit": 50, "session_time_minutes": 15}
+    base = {"daily_new_cards": 10, "daily_goal_cards": 150,
+            "session_card_limit": 50, "session_time_minutes": 15,
+            "study_ahead_enabled": 0}
     base.update(overrides)
     return base
 
@@ -20,36 +25,36 @@ def test_new_card_cap_is_respected(storage, service):
     assert all(row["reps"] == 0 for row in queue)
 
 
-def test_review_card_cap_is_respected(storage, service, clock):
+def test_daily_goal_caps_the_queue(storage, service, clock):
     past = clock.now() - timedelta(days=3)
     for i in range(1, 61):
         seed_card(storage, service, i, reps=1, due=past)
     queue = service.get_due_cards(
-        limits=_limits(daily_review_cards=40, daily_new_cards=0,
+        limits=_limits(daily_goal_cards=40, daily_new_cards=0,
                        session_card_limit=100))
     assert len(queue) == 40
     assert all(row["reps"] > 0 for row in queue)
 
 
-def test_session_cap_trumps_daily_caps(storage, service, clock):
+def test_sprint_cap_trumps_daily_budgets(storage, service, clock):
     past = clock.now() - timedelta(days=1)
     for i in range(1, 21):
         seed_card(storage, service, i, reps=1, due=past)
     for i in range(21, 41):
         seed_card(storage, service, i)
     queue = service.get_due_cards(
-        limits=_limits(daily_new_cards=20, daily_review_cards=20,
-                       session_card_limit=15))
+        limits=_limits(daily_new_cards=20, session_card_limit=15))
     assert len(queue) == 15
 
 
-def test_backlog_does_not_override_cap(storage, service, clock):
-    # A week of missed reviews: 500 due cards must not flood the child.
+def test_backlog_does_not_flood_a_sprint(storage, service, clock):
+    # A week of missed reviews: 500 due cards arrive one sprint at a
+    # time, never all at once.
     long_ago = clock.now() - timedelta(days=30)
     for i in range(1, 501):
         seed_card(storage, service, i, reps=2, due=long_ago)
     queue = service.get_due_cards(limits=_limits())
-    assert len(queue) == 40  # daily_review_cards, not 500
+    assert len(queue) == 50  # session_card_limit, not 500
 
 
 def test_reviews_come_before_new_cards(storage, service, clock):
@@ -72,16 +77,31 @@ def test_most_overdue_reviews_first(storage, service, clock):
 def test_daily_cap_counts_work_already_done_today(storage, service, clock):
     for i in range(1, 16):
         seed_card(storage, service, i)
-    # Answer 6 new cards in a first sitting.
+    # Answer 6 new cards in a first sprint.
     for row in service.get_due_cards(limits=_limits(daily_new_cards=6)):
         service.answer_card(row["id"], 3)
-    # Second sitting the same day: only 4 new remain under a cap of 10.
+    # Second sprint the same day: only 4 new remain under a cap of 10.
     queue = service.get_due_cards(limits=_limits(daily_new_cards=10))
     new_ids = {row["id"] for row in queue if row["reps"] == 0}
     assert len(new_ids) == 4
 
 
-def test_daily_caps_reset_at_local_midnight(storage, service, clock):
+def test_goal_counts_every_answer_not_unique_cards(storage, service, clock):
+    # Two answers on the same card (a learning-step repeat) both count
+    # toward the goal: the contract is "N cards answered", not "N
+    # distinct cards".
+    seed_card(storage, service, 1)
+    seed_card(storage, service, 2, reps=1,
+              due=clock.now() - timedelta(days=1))
+    limits = _limits(daily_goal_cards=2, daily_new_cards=10)
+    service.answer_card(1, 1)  # Again: the card comes back...
+    service.answer_card(1, 3)  # ...and the repeat is a second answer.
+    # Card 2 is due, but the goal budget is already spent; per-unique-
+    # card accounting would have left room for it.
+    assert service.get_due_cards(limits=limits) == []
+
+
+def test_daily_budgets_reset_at_local_midnight(storage, service, clock):
     for i in range(1, 6):
         seed_card(storage, service, i)
     limits = _limits(daily_new_cards=5)

--- a/cardbrick-py/tests/test_study_ahead.py
+++ b/cardbrick-py/tests/test_study_ahead.py
@@ -1,0 +1,319 @@
+"""Studying ahead: sprint accounting, ahead fill, and bonus sprints.
+
+The day is a card goal chipped away in 5-10 minute sprints; a child
+with spare time can "go ahead" — do the next sprints now and owe fewer
+later — and, once the goal is met, optionally keep going on soon-due
+cards pulled forward (safe under FSRS: early reviews just earn a
+smaller stability gain).
+"""
+
+import sqlite3
+from datetime import datetime, timedelta
+
+from conftest import seed_card
+
+from cardbrick.scheduler import iso
+from cardbrick.service import local_day_start
+from cardbrick.session import StudySession
+from cardbrick.storage import Storage
+
+
+def _limits(**overrides):
+    base = {"daily_new_cards": 10, "daily_goal_cards": 150,
+            "session_card_limit": 20, "session_time_minutes": 10,
+            "study_ahead_days": 1, "study_ahead_enabled": 1}
+    base.update(overrides)
+    return base
+
+
+def _ids(queue):
+    return [row["id"] for row in queue]
+
+
+# -- sprint accounting ---------------------------------------------------------
+
+
+def test_sprint_status_derives_counts_from_the_log(storage, service, clock):
+    for i in range(1, 7):
+        seed_card(storage, service, i)
+    limits = _limits(daily_goal_cards=40, daily_new_cards=6,
+                     session_card_limit=10, study_ahead_enabled=0)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_done"] == 0
+    assert status["sprints_planned"] == 4
+    assert status["sprints_remaining"] == 4
+    assert status["next_sprint_cards"] == 6
+
+    for card_id in (1, 2, 3):
+        service.answer_card(card_id, 4)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_done"] == 3
+    assert status["cards_remaining"] == 37
+    assert status["sprints_remaining"] == 4  # ceil(37 / 10)
+
+
+def test_going_ahead_decrements_sprints_remaining(storage, service, clock):
+    # Three back-to-back sprints burn down three sprints' worth of the
+    # goal — spare time now means fewer sprints owed later.
+    long_ago = clock.now() - timedelta(days=10)
+    for i in range(1, 31):
+        seed_card(storage, service, i, reps=2, due=long_ago)
+    limits = _limits(daily_goal_cards=30, daily_new_cards=0,
+                     session_card_limit=10, study_ahead_enabled=0)
+    assert service.sprint_status(limits=limits)["sprints_remaining"] == 3
+
+    for expected_left in (2, 1, 0):
+        for row in service.get_due_cards(limits=limits):
+            service.answer_card(row["id"], 4)
+        status = service.sprint_status(limits=limits)
+        assert status["sprints_remaining"] == expected_left
+    assert status["next_sprint_cards"] == 0  # goal met: nothing owed
+
+
+def test_partial_sprint_earns_partial_credit(storage, service, clock):
+    # Quitting a sprint early only banks the cards actually answered;
+    # the remaining count stays honest.
+    long_ago = clock.now() - timedelta(days=10)
+    for i in range(1, 21):
+        seed_card(storage, service, i, reps=2, due=long_ago)
+    limits = _limits(daily_goal_cards=20, daily_new_cards=0,
+                     session_card_limit=10, study_ahead_enabled=0)
+    for row in service.get_due_cards(limits=limits)[:4]:
+        service.answer_card(row["id"], 4)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_done"] == 4
+    assert status["sprints_remaining"] == 2  # ceil(16 / 10)
+
+
+def test_undo_restores_the_sprint_count(storage, service, clock):
+    seed_card(storage, service, 1)
+    limits = _limits(daily_goal_cards=1, daily_new_cards=1,
+                     study_ahead_enabled=0)
+    session_id = storage.create_session(None, iso(clock.now()), None)
+    service.answer_card(1, 4, session_id=session_id)
+    assert service.sprint_status(limits=limits)["cards_remaining"] == 0
+
+    service.undo_last_answer(session_id)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_remaining"] == 1
+    assert status["next_sprint_cards"] == 1
+
+
+# -- ahead fill ---------------------------------------------------------------
+
+
+def test_ahead_fill_tops_up_when_due_pool_runs_dry(storage, service, clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now - timedelta(hours=1))
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(hours=20))
+    seed_card(storage, service, 3, reps=1, due=now + timedelta(hours=4))
+    queue = service.get_due_cards(limits=_limits(daily_new_cards=0))
+    # Due card first, then soon-due cards pulled forward, soonest first.
+    assert _ids(queue) == [1, 3, 2]
+
+
+def test_ahead_fill_respects_the_horizon(storage, service, clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now + timedelta(hours=20))
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(days=3))
+    one_day = service.get_due_cards(
+        limits=_limits(daily_new_cards=0, study_ahead_days=1))
+    assert _ids(one_day) == [1]
+    three_days = service.get_due_cards(
+        limits=_limits(daily_new_cards=0, study_ahead_days=3))
+    assert _ids(three_days) == [1, 2]
+
+
+def test_ahead_fill_only_after_due_and_new(storage, service, clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now + timedelta(hours=5))
+    seed_card(storage, service, 2)  # new
+    seed_card(storage, service, 3, reps=1, due=now - timedelta(hours=1))
+    queue = service.get_due_cards(limits=_limits())
+    assert _ids(queue) == [3, 2, 1]  # due, new, then ahead
+
+
+def test_ahead_fill_never_resurrects_buried_or_suspended(storage, service,
+                                                         clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now + timedelta(hours=5))
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(hours=6))
+    seed_card(storage, service, 3, reps=1, due=now + timedelta(hours=7))
+    service.bury_card(1)      # "not today" must hold against ahead fill
+    service.suspend_card(2)
+    queue = service.get_due_cards(limits=_limits(daily_new_cards=0))
+    assert _ids(queue) == [3]
+
+
+def test_ahead_fill_respects_deck_and_category_filters(storage, service,
+                                                       clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now + timedelta(hours=5),
+              deck="Spanish", tags="food")
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(hours=5),
+              deck="French", tags="food")
+    seed_card(storage, service, 3, reps=1, due=now + timedelta(hours=5),
+              deck="Spanish", tags="numbers")
+    queue = service.get_due_cards(deck_filter=["Spanish"],
+                                  category_filter=["food"],
+                                  limits=_limits(daily_new_cards=0))
+    assert _ids(queue) == [1]
+
+
+def test_study_ahead_disabled_means_the_day_ends_early(storage, service,
+                                                       clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() + timedelta(hours=5))
+    limits = _limits(daily_new_cards=0, study_ahead_enabled=0)
+    assert service.get_due_cards(limits=limits) == []
+    status = service.sprint_status(limits=limits)
+    assert status["next_sprint_cards"] == 0
+    assert status["bonus_cards"] == 0
+
+
+# -- FSRS early review ---------------------------------------------------------
+
+
+def test_early_review_produces_a_sane_state(storage, service, clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() + timedelta(hours=20))
+    state, _came_back = service.answer_card(1, 3)
+    assert state["reps"] == 2
+    assert datetime.fromisoformat(state["due"]) > clock.now()
+
+
+def test_again_on_an_ahead_card_comes_back_in_session(storage, service,
+                                                      clock):
+    seed_card(storage, service, 1, reps=1,
+              due=clock.now() + timedelta(hours=20))
+    _state, came_back = service.answer_card(1, 1)
+    assert came_back  # LEARN_AHEAD requeue works the same when ahead
+
+
+# -- bonus sprints -------------------------------------------------------------
+
+
+def test_bonus_sprint_offered_only_after_goal_met(storage, service, clock):
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now - timedelta(hours=1))
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(hours=20))
+    limits = _limits(daily_goal_cards=1, daily_new_cards=0)
+
+    status = service.sprint_status(limits=limits)
+    assert status["next_sprint_cards"] == 1  # goal still open: no bonus
+    assert status["bonus_cards"] == 0
+
+    service.answer_card(1, 4)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_remaining"] == 0
+    assert status["next_sprint_cards"] == 0
+    assert status["bonus_cards"] >= 1  # card 2 pulled forward
+
+
+def test_bonus_sprints_drain_the_ahead_pool(storage, service, clock):
+    # Each early review pushes the card's due date out, so repeated
+    # bonus sprints terminate on their own.
+    now = clock.now()
+    for i in range(1, 6):
+        seed_card(storage, service, i, reps=1,
+                  due=now + timedelta(hours=12 + i))
+    limits = _limits(daily_goal_cards=0, daily_new_cards=0)
+    for _round in range(20):  # safety bound; should finish much sooner
+        queue = service.get_due_cards(limits=limits, bonus=True)
+        if not queue:
+            break
+        for row in queue:
+            service.answer_card(row["id"], 4)  # Easy: due leaves horizon
+    assert service.get_due_cards(limits=limits, bonus=True) == []
+
+
+def test_bonus_session_flows_through_study_session(storage, service, clock,
+                                                   profile):
+    storage.update_profile(profile["id"], daily_goal_cards=1,
+                           daily_new_cards=0)
+    profile = storage.get_profile(profile["id"])
+    now = clock.now()
+    seed_card(storage, service, 1, reps=1, due=now - timedelta(hours=1))
+    seed_card(storage, service, 2, reps=1, due=now + timedelta(hours=20))
+    service.answer_card(1, 4)  # goal of 1 met
+
+    session = StudySession(storage, service, profile, bonus=True)
+    assert session.planned_total == 1
+    card = session.current_card()
+    assert card["id"] == 2
+    session.answer(4)
+    summary = session.finish()
+    assert summary["cards_reviewed"] == 1
+    # Bonus sprints still earn a stamp on the calendar.
+    when = now.astimezone()
+    stamps = service.sessions_per_day(profile["id"], when.year, when.month)
+    assert stamps[when.day] >= 1
+
+
+# -- rollover ------------------------------------------------------------------
+
+
+def test_day_rolls_over_clean_after_going_ahead(storage, service, clock):
+    seed_card(storage, service, 1)
+    limits = _limits(daily_goal_cards=1, daily_new_cards=1,
+                     study_ahead_enabled=0)
+    service.answer_card(1, 4)
+    assert service.sprint_status(limits=limits)["cards_remaining"] == 0
+
+    clock.advance(days=1)
+    status = service.sprint_status(limits=limits)
+    assert status["cards_done"] == 0  # yesterday's work stays yesterday's
+    assert status["cards_remaining"] == 1
+
+
+# -- migration -----------------------------------------------------------------
+
+
+def test_migration_seeds_goal_from_old_caps(tmp_path):
+    # A schema-v4 database (pre-goal): opening it must add the new
+    # columns and seed daily_goal_cards from the old review+new caps so
+    # nobody's day suddenly triples.
+    db_path = str(tmp_path / "old.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+        INSERT INTO meta VALUES ('schema_version', '4');
+        CREATE TABLE cards (
+            id INTEGER PRIMARY KEY, note_id INTEGER NOT NULL,
+            deck TEXT NOT NULL, front TEXT NOT NULL, back TEXT NOT NULL,
+            tags TEXT NOT NULL DEFAULT '', audio_filename TEXT,
+            audio_side TEXT, suspended INTEGER NOT NULL DEFAULT 0,
+            buried_until TEXT, created_at TEXT, updated_at TEXT,
+            card_type TEXT NOT NULL DEFAULT 'basic');
+        CREATE TABLE child_profiles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
+            active_categories TEXT, active_decks TEXT,
+            daily_new_cards INTEGER NOT NULL DEFAULT 10,
+            daily_review_cards INTEGER NOT NULL DEFAULT 40,
+            session_card_limit INTEGER NOT NULL DEFAULT 50,
+            session_time_minutes INTEGER NOT NULL DEFAULT 15,
+            study_direction TEXT NOT NULL DEFAULT 'normal');
+        INSERT INTO child_profiles (name, daily_new_cards,
+                                    daily_review_cards)
+        VALUES ('Maya', 5, 30);
+    """)
+    conn.commit()
+    conn.close()
+
+    storage = Storage(db_path)
+    try:
+        assert storage.schema_version() == 5
+        maya = storage.list_profiles()[0]
+        assert maya["daily_goal_cards"] == 35  # 5 new + 30 review
+        assert maya["study_ahead_days"] == 1
+        assert maya["study_ahead_enabled"] == 1
+    finally:
+        storage.close()
+
+
+def test_answers_before_day_start_do_not_count(storage, service, clock):
+    day_start = local_day_start(clock.now())
+    assert storage.daily_answer_count(iso(day_start)) == 0
+    seed_card(storage, service, 1)
+    service.answer_card(1, 3)
+    assert storage.daily_answer_count(iso(day_start)) == 1

--- a/docs/STUDYING_AHEAD_PLAN.md
+++ b/docs/STUDYING_AHEAD_PLAN.md
@@ -1,210 +1,210 @@
-# Plan: Studying Ahead
+# Plan: Studying Ahead (sprint-based microstudying)
 
-## The problem
+## The model
 
-When a child finishes their queue, the app says *"All done for today! Come
-back tomorrow."* and there is nothing else to do — even if they have spare
-time and want to keep going. Concretely, in `cardbrick-py`:
+CardBrick is a microstudying app: the child is not supposed to sit down
+once and clear a queue, they are supposed to chip away at a **daily card
+goal** (say 150 cards) in **5–10 minute sprints** spread across the day.
 
-* `ReviewService.get_due_cards` (`cardbrick/service.py`) builds the queue
-  from cards with `due <= now` plus new cards, capped by
-  `daily_review_cards` / `daily_new_cards` **minus work already logged
-  today**. Once the day's caps are consumed and nothing is overdue, the
-  queue is empty.
-* `screen_child_start` (`cardbrick/app.py`) only offers Start when
-  `counts_for_queue` is non-zero; otherwise the child hits a dead end.
-* `screen_summary` returns to `CHILD_START`, which then shows the dead end.
+Two numbers drive everything:
 
-The goal: after finishing, the child can immediately start another session
-— "studying ahead" — pulling in cards that are due soon (tomorrow, or the
-next few days) and optionally a few bonus new cards, without breaking the
-daily-cap safety rails for normal sessions.
+* `daily_goal_cards` — how many card answers the child should log today
+  (parent-set, e.g. 150);
+* a **sprint** — one `StudySession`, already bounded by
+  `session_card_limit` (cards per sitting) and `session_time_minutes`
+  (5–10 min).
 
-Note that one case already works today and must keep working: if the child
-ends a session early (time limit, "End session") while daily caps are not
-yet exhausted, starting again simply resumes the remainder — the caps are
-derived from the review log, so no change is needed there. This plan is
-about the case where **nothing** is left for today.
+From these we derive, always from the append-only review log (never
+in-memory counters, matching the house style):
 
-## Why this is safe with FSRS
+```
+cards_done_today   = non-undone review-log entries since local midnight
+cards_remaining    = max(daily_goal_cards - cards_done_today, 0)
+sprints_remaining  = ceil(cards_remaining / session_card_limit)
+sprints_planned    = ceil(daily_goal_cards / session_card_limit)
+```
 
-Scheduling is delegated to py-fsrs (`cardbrick/scheduler.py`). FSRS
-computes the next state from the *actual* elapsed time since the last
-review, so reviewing a card before its due date is well-defined: the
-stability gain is simply smaller than it would have been on time. No
-interval hacks or "pretend it was due" adjustments are needed — we just
-show the card and rate it normally. (This is a real advantage over the
-legacy Rust SM-2 app, where early reviews would corrupt intervals; see
-"Out of scope" below.)
+The child should always see **how many sprints they still owe today**,
+and **"going ahead" — doing the next sprint right now instead of waiting
+— decrements that count**. A child with unexpected spare time can knock
+out three sprints back-to-back and owe three fewer later. Deriving the
+count from *cards*, not from completed sessions, means a sprint cut short
+by the time limit only earns partial credit and the arithmetic stays
+honest across undo, crashes, and restarts.
+
+## What's wrong today
+
+The current code models exactly one queue per day and then stops:
+
+* `ReviewService.get_due_cards` (`cardbrick/service.py`) caps the queue
+  by `daily_review_cards` / `daily_new_cards` minus work already logged.
+  Once the caps are consumed, the queue is empty for the rest of the day.
+* `screen_child_start` (`cardbrick/app.py`) then shows *"All done for
+  today! Come back tomorrow."* — a dead end that tells the child the
+  opposite of what we want. There is no notion of a goal, a sprint, or
+  "you're 3 of 8 through your day".
+* `screen_summary` says "SESSION COMPLETE / ¡Buen trabajo!" and routes
+  back to that dead end. Nothing invites the next sprint.
+
+One thing does already work and must keep working: caps are log-derived,
+so quitting mid-day and coming back resumes the remainder. The change is
+the framing (goal/sprints) and what happens when today's due pool runs
+dry before the goal is met.
 
 ## Design
 
-### 1. Ahead queue builder (service + storage)
+### 1. Goal-driven queue budget (service)
 
-New storage query, alongside `queue_candidates`
-(`cardbrick/storage.py:314`):
+`daily_goal_cards` becomes the day's review budget, replacing
+`daily_review_cards` in the queue math (`get_due_cards`):
+
+* `remaining_review = max(daily_goal_cards - cards_done_today, 0)` —
+  answers, not unique cards: learning-step repeats within a sprint count
+  toward the goal, which is correct for a "150 cards a day" contract.
+* `daily_new_cards` keeps its current meaning — it paces how fast new
+  material enters FSRS, which is orthogonal to the goal.
+* `daily_review_cards` is retired from queue-building (column stays for
+  migration compatibility; the CLI stops offering it).
+* Each sprint's queue is then, as today, truncated to
+  `session_card_limit` — one sprint's worth.
+
+New service helper used by every screen:
+
+```
+sprint_status(profile, deck_filter=None) ->
+    {cards_done, cards_remaining, sprints_remaining, sprints_planned,
+     next_sprint_size}
+```
+
+### 2. Filling sprints when the due pool runs dry (storage + service)
+
+A goal of 150 can exceed what FSRS has due today. When due reviews + new
+cards can't fill the remaining budget, sprints are topped up with
+**ahead cards** — cards due soon, pulled forward. FSRS makes this sound:
+py-fsrs computes the next state from actual elapsed time, so an early
+review is well-defined (just a smaller stability gain). No interval
+hacks.
+
+New storage query alongside `queue_candidates` (`storage.py:314`):
 
 ```
 ahead_candidates(now_iso, horizon_iso, decks=None)
-    -> review cards with reps > 0 AND due > :now AND due <= :horizon,
+    -> reps > 0 AND due > :now AND due <= :horizon,
        not suspended, not buried, ordered by due (soonest first)
 ```
 
-New service method in `cardbrick/service.py`:
+`get_due_cards` gains a final fill stage: due reviews → new cards →
+ahead cards (horizon = next local midnight + `study_ahead_days`, default
+1), all still truncated to the sprint size. Buried cards stay excluded —
+bury means "not today", and no fill stage may resurrect them.
 
-```
-get_ahead_cards(profile=None, category_filter=None, deck_filter=None,
-                limits=None)
-```
+The ahead pool self-limits: every early review pushes that card's due
+date out past the horizon, so back-to-back sprints drain it naturally.
 
-Behaviour:
+### 3. Sprint-aware UI (`cardbrick/app.py`)
 
-* Horizon = next local midnight + `study_ahead_days` days (profile field,
-  default 1 → "tomorrow's cards"). Reuses `next_local_midnight`.
-* **Ignores** `daily_review_cards` / `daily_new_cards` — those caps are
-  exhausted by definition when this queue is offered. Bounding comes from:
-  * `session_card_limit` and `session_time_minutes` (unchanged, still
-    enforced by `StudySession`);
-  * the horizon itself — each early review pushes the card's due date out,
-    so the ahead pool shrinks as it is studied and repeated ahead sessions
-    naturally dry up;
-  * `study_ahead_extra_new` (profile field, default 0): a per-day bonus of
-    new cards allowed beyond `daily_new_cards`. Computed from the review
-    log like the other caps (`max(daily_new_cards + study_ahead_extra_new
-    - new_done, 0)`), so it survives restarts and undo.
-* Order: soon-due review cards first (most urgent first), then bonus new
-  cards — same shape as the normal queue.
-* Same category/deck filtering and profile fallbacks as `get_due_cards`.
-* Companion `counts_for_ahead_queue(...)` mirroring `counts_for_queue`,
-  for the start screen label.
+`screen_child_start` — replace the due-count framing with goal framing:
 
-Gate: `study_ahead_enabled` profile field (default 1). When off,
-`get_ahead_cards` returns `[]` and the UI never shows the option.
+* Big line: **"5 sprints to go today"** (from `sprint_status`).
+* Progress line: "72 / 150 cards" (a simple bar fits the existing
+  drawing helpers).
+* Detail: "next sprint: ~20 cards, up to 7 min".
+* Bottom button always starts the next sprint while
+  `sprints_remaining > 0` — never a dead end mid-goal.
+* Goal met (`cards_remaining == 0`): celebrate — "Goal reached! 🎉
+  8 sprints done" — and offer a **bonus sprint** from the ahead pool if
+  it's non-empty ("keep going: N cards from tomorrow"). Only when the
+  ahead pool is also empty show "Come back tomorrow."
 
-### 2. Session plumbing
+`screen_summary` — this is where "going ahead" lives:
 
-`StudySession` (`cardbrick/session.py`) takes an optional `ahead=False`
-flag:
+* "Sprint done! **4 sprints to go** today" instead of the generic
+  session-complete banner (keep the stats lines).
+* Bottom button = **next sprint now** (straight into `REVIEW`, reusing
+  the deck filter from this sitting); east button = done for now (back to
+  start screen). A child with momentum never bounces through a menu.
+* After the last sprint: goal celebration + bonus-sprint offer, same as
+  the start screen.
 
-* When `ahead=True`, it seeds its queue from `get_ahead_cards` instead of
-  `get_due_cards`. Everything else — answering, LEARN_AHEAD requeue of
-  learning cards, undo, bury/suspend, summary, session row — is unchanged
-  and works as-is, because answers flow through the same
-  `ReviewService.answer_card` path.
-* The session row records that it was an ahead session (see migration
-  below) so the calendar/stats can distinguish it later if wanted. Ahead
-  sessions still earn a calendar stamp — extra effort should be rewarded,
-  and `sessions_per_day` already counts any session with reviews.
+`_draw_review` header — show "Sprint 4/8" next to the existing
+"{n} left" label so the child always knows where they are in the day.
 
-### 3. UI flow (`cardbrick/app.py`)
-
-* `screen_child_start`: when the normal queue is empty **and**
-  `counts_for_ahead_queue` > 0, replace the dead end with:
-
-  * "All done for today! ⭐" (keep the celebration)
-  * "Study ahead: N cards from tomorrow" + "Press the bottom button to
-    keep going!"
-  * Bottom button starts an ahead session (via `DECK_SELECT` when more
-    than one deck is assigned, same as today, with ahead counts shown).
-
-  When the ahead pool is also empty (deck truly exhausted or feature
-  disabled), keep the current "Come back tomorrow." message.
-* `screen_summary`: add a third action — when the normal queue is empty
-  but ahead cards exist, show "… = Study ahead" in the footer and start
-  the next session directly, so a child with momentum never has to bounce
-  through the start screen. (When normal cards remain — e.g. the session
-  ended on the time limit — the existing "Done → start screen → Start"
-  path already covers "go again", so the summary shortcut can offer that
-  too, but that is polish, not core.)
-* A small visual marker during ahead sessions (e.g. "STUDYING AHEAD" in
-  the header where `_draw_review` puts the deck/remaining labels) so the
-  log, the child, and a watching parent all know these are bonus reviews.
-* State passed the same way as the existing deck filter
-  (`self._session_deck_filter`): an `self._session_ahead` flag cleared by
-  `screen_child_start`.
+`screen_deck_select` is unchanged except its counts come from the same
+sprint-sized queue builder.
 
 ### 4. Parent controls
 
-New profile columns, wired through the existing machinery:
+New profile columns, wired through the existing versioned migration
+(`storage.py` ~124–137, schema-version bump) and both profile-update
+allowlists (`storage.py:538, :554`) so the profile CLI can set them:
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `study_ahead_enabled` | INTEGER (bool) | 1 | Offer ahead sessions at all |
-| `study_ahead_days` | INTEGER | 1 | How far past midnight the horizon reaches |
-| `study_ahead_extra_new` | INTEGER | 0 | Bonus new cards/day during ahead sessions |
+| `daily_goal_cards` | INTEGER | 150 | Card answers per day; drives sprint count |
+| `study_ahead_days` | INTEGER | 1 | How far forward the ahead fill may reach |
+| `study_ahead_enabled` | INTEGER (bool) | 1 | Allow ahead fill + bonus sprints |
 
-* Schema: add to `CREATE TABLE profiles` and to the ALTER-TABLE migration
-  map (`storage.py` ~line 124–137) with a schema-version bump — the
-  versioned in-place migration path already exists.
-* Add the fields to the two profile-update allowlists
-  (`storage.py:538, :554`) so the profile CLI can set them
-  (`cardbrick-cli`), matching how `session_card_limit` etc. are managed.
-* Parent Mode screens: not required for v1 (parents manage limits via the
-  CLI today); can be added to the parent menu later alongside the other
-  limit editing.
+Sprint size/length stay on the existing `session_card_limit` /
+`session_time_minutes` fields (parents should set them to the 5–10 min
+range; suggested new defaults: 20 cards / 7 minutes, tuned so
+`150 / 20 ≈ 8` sprints).
+
+Migration note: initialize `daily_goal_cards` for existing profiles from
+`daily_review_cards + daily_new_cards` so nobody's day suddenly triples.
 
 ### 5. Tests (`cardbrick-py/tests/test_study_ahead.py`)
 
-Following the house style (injected `now_fn`, log-derived counters):
+Injected `now_fn`, log-derived assertions, following the house style:
 
-1. **Pool selection** — `get_ahead_cards` returns only cards with
-   `now < due <= horizon`, soonest first; suspended and buried cards are
-   excluded; deck/category filters apply.
-2. **Horizon** — `study_ahead_days=1` picks up tomorrow's cards but not
-   the day after; `study_ahead_days=2` picks up both.
-3. **Caps** — daily review/new caps exhausted → normal queue empty, ahead
-   queue non-empty; `session_card_limit` still truncates; bonus new cards
-   appear only up to `study_ahead_extra_new` and are counted from the log
-   (undo restores the allowance).
-4. **Gate** — `study_ahead_enabled=0` → empty ahead queue.
-5. **FSRS early review** — answering an ahead card produces a valid state
-   with `due > now` and doesn't reduce reps/stability bookkeeping;
-   answering it Again brings it back within the session (LEARN_AHEAD path
-   unchanged).
-6. **Shrinking pool** — after an ahead session covers the whole horizon,
-   a second ahead session finds (almost) nothing: the loop terminates.
-7. **Session row** — ahead sessions are flagged, still counted by
-   `sessions_per_day`, and `summary()` numbers are correct.
-8. **Regression guard** — mid-day resume with unexhausted caps still
-   works exactly as before (normal queue, no ahead flag).
+1. **Sprint math** — `sprint_status` derives counts from the log; a
+   partial sprint (ended early) decrements cards, not a whole sprint;
+   undo restores the count.
+2. **Going ahead decrements** — three back-to-back sprints reduce
+   `sprints_remaining` by three; caps never block a sprint while the
+   goal is unmet.
+3. **Goal budget** — queue building stops at `daily_goal_cards`;
+   `daily_new_cards` still paces new cards; `session_card_limit` still
+   truncates each sprint.
+4. **Ahead fill** — kicks in only when due + new can't fill the budget;
+   respects horizon, ordering (soonest due first), suspended/buried
+   exclusion, deck/category filters; disabled cleanly by
+   `study_ahead_enabled=0` (day ends early instead).
+5. **FSRS early review** — an ahead card answered early gets a valid
+   state with `due > now`; Again brings it back within the sprint
+   (LEARN_AHEAD path unchanged).
+6. **Bonus sprint** — available after goal met while the ahead pool is
+   non-empty; pool drains to empty across repeated bonus sprints (the
+   loop terminates).
+7. **Rollover** — a sprint straddling local midnight books its answers
+   to the day they were logged; tomorrow's status starts clean.
+8. **Migration** — existing profiles get a sane `daily_goal_cards`.
 
 ## Implementation order
 
-Each step lands independently and keeps the suite green:
+Each step lands independently with the suite green:
 
-1. **Storage**: `ahead_candidates` query + profile columns + migration +
-   allowlists (+ tests 1, 2 partially).
-2. **Service**: `get_ahead_cards`, `counts_for_ahead_queue`, bonus-new
-   accounting (+ tests 1–4).
-3. **Session**: `ahead=` flag, session-row flag (+ tests 5–8).
-4. **UI**: start-screen offer, summary shortcut, deck-select counts,
-   review-header marker. Manual smoke on desktop pygame
-   (`cardbrick-py/main.py`) since screens are loop-driven.
-5. **CLI**: expose the three fields in the profile CLI; update
-   `docs/CLI_API.md` / developer guide if they enumerate profile fields.
-
-## Edge cases called out
-
-* **Buried cards** stay excluded from ahead sessions — bury means "not
-  today", and studying ahead must not resurrect them.
-* **Learning-state cards due later today** (rated Again/Hard earlier) fall
-  inside any horizon and are the most valuable content — they come first
-  because ordering is by due date.
-* **Midnight rollover mid-session**: all accounting is log-derived, so an
-  ahead session straddling midnight just means tomorrow starts with those
-  cards already pushed out. No special handling.
-* **Undo** in an ahead session restores state exactly (existing snapshot
-  mechanism) — including the bonus-new allowance, since it's log-derived.
+1. **Storage**: profile columns + migration + allowlists;
+   `ahead_candidates` query.
+2. **Service**: goal-budget queue math, ahead fill stage,
+   `sprint_status` (tests 1–5).
+3. **Session**: no structural change expected — a sprint *is* a
+   `StudySession`; verify summary/counters need nothing new (test 6–7
+   land here).
+4. **UI**: start screen, summary "next sprint now" flow, review header,
+   deck-select counts. Manual smoke via desktop pygame
+   (`cardbrick-py/main.py`).
+5. **CLI + docs**: expose the new fields, retire `daily_review_cards`
+   from the CLI, update `docs/CLI_API.md` / developer guide.
 
 ## Out of scope
 
-* **The legacy Rust app** (`src/`). It has the same dead end (the daily
-  queue file in `src/scheduler/queue.rs` is built once per day, and
-  `continue_studying` in `src/scenes/studying/logic.rs` only reshuffles or
-  previews new cards), but its SM-2 scheduler has no sound notion of early
-  review, and active development has moved to `cardbrick-py`. If wanted
-  later, the equivalent would be a separate design (SM-2 needs an
-  elapsed/scheduled interval adjustment for early reviews).
-* Parent Mode screens for the new fields (CLI-only in v1).
-* Any change to points/gamification — `cardbrick-py` has no points
-  system; the stamp calendar already rewards extra sessions.
+* **The legacy Rust app** (`src/`): same dead end (daily queue file in
+  `src/scheduler/queue.rs` built once per day), but its SM-2 scheduler
+  has no sound notion of early review and active development has moved
+  to `cardbrick-py`. An SM-2 review-ahead needs its own design
+  (elapsed/scheduled interval adjustment) if ever wanted.
+* Scheduled sprint reminders across the day (notifications/alarms) —
+  the sprint count tells the child what they owe; nagging hardware
+  timers are a separate feature.
+* Parent Mode screens for the new fields (CLI-only in v1, like the
+  other limits).

--- a/docs/STUDYING_AHEAD_PLAN.md
+++ b/docs/STUDYING_AHEAD_PLAN.md
@@ -146,7 +146,7 @@ allowlists (`storage.py:538, :554`) so the profile CLI can set them:
 
 Sprint size/length stay on the existing `session_card_limit` /
 `session_time_minutes` fields (parents should set them to the 5–10 min
-range; suggested new defaults: 20 cards / 7 minutes, tuned so
+range; new defaults: 20 cards / 10 minutes, tuned so
 `150 / 20 ≈ 8` sprints).
 
 Migration note: initialize `daily_goal_cards` for existing profiles from

--- a/docs/STUDYING_AHEAD_PLAN.md
+++ b/docs/STUDYING_AHEAD_PLAN.md
@@ -1,0 +1,210 @@
+# Plan: Studying Ahead
+
+## The problem
+
+When a child finishes their queue, the app says *"All done for today! Come
+back tomorrow."* and there is nothing else to do — even if they have spare
+time and want to keep going. Concretely, in `cardbrick-py`:
+
+* `ReviewService.get_due_cards` (`cardbrick/service.py`) builds the queue
+  from cards with `due <= now` plus new cards, capped by
+  `daily_review_cards` / `daily_new_cards` **minus work already logged
+  today**. Once the day's caps are consumed and nothing is overdue, the
+  queue is empty.
+* `screen_child_start` (`cardbrick/app.py`) only offers Start when
+  `counts_for_queue` is non-zero; otherwise the child hits a dead end.
+* `screen_summary` returns to `CHILD_START`, which then shows the dead end.
+
+The goal: after finishing, the child can immediately start another session
+— "studying ahead" — pulling in cards that are due soon (tomorrow, or the
+next few days) and optionally a few bonus new cards, without breaking the
+daily-cap safety rails for normal sessions.
+
+Note that one case already works today and must keep working: if the child
+ends a session early (time limit, "End session") while daily caps are not
+yet exhausted, starting again simply resumes the remainder — the caps are
+derived from the review log, so no change is needed there. This plan is
+about the case where **nothing** is left for today.
+
+## Why this is safe with FSRS
+
+Scheduling is delegated to py-fsrs (`cardbrick/scheduler.py`). FSRS
+computes the next state from the *actual* elapsed time since the last
+review, so reviewing a card before its due date is well-defined: the
+stability gain is simply smaller than it would have been on time. No
+interval hacks or "pretend it was due" adjustments are needed — we just
+show the card and rate it normally. (This is a real advantage over the
+legacy Rust SM-2 app, where early reviews would corrupt intervals; see
+"Out of scope" below.)
+
+## Design
+
+### 1. Ahead queue builder (service + storage)
+
+New storage query, alongside `queue_candidates`
+(`cardbrick/storage.py:314`):
+
+```
+ahead_candidates(now_iso, horizon_iso, decks=None)
+    -> review cards with reps > 0 AND due > :now AND due <= :horizon,
+       not suspended, not buried, ordered by due (soonest first)
+```
+
+New service method in `cardbrick/service.py`:
+
+```
+get_ahead_cards(profile=None, category_filter=None, deck_filter=None,
+                limits=None)
+```
+
+Behaviour:
+
+* Horizon = next local midnight + `study_ahead_days` days (profile field,
+  default 1 → "tomorrow's cards"). Reuses `next_local_midnight`.
+* **Ignores** `daily_review_cards` / `daily_new_cards` — those caps are
+  exhausted by definition when this queue is offered. Bounding comes from:
+  * `session_card_limit` and `session_time_minutes` (unchanged, still
+    enforced by `StudySession`);
+  * the horizon itself — each early review pushes the card's due date out,
+    so the ahead pool shrinks as it is studied and repeated ahead sessions
+    naturally dry up;
+  * `study_ahead_extra_new` (profile field, default 0): a per-day bonus of
+    new cards allowed beyond `daily_new_cards`. Computed from the review
+    log like the other caps (`max(daily_new_cards + study_ahead_extra_new
+    - new_done, 0)`), so it survives restarts and undo.
+* Order: soon-due review cards first (most urgent first), then bonus new
+  cards — same shape as the normal queue.
+* Same category/deck filtering and profile fallbacks as `get_due_cards`.
+* Companion `counts_for_ahead_queue(...)` mirroring `counts_for_queue`,
+  for the start screen label.
+
+Gate: `study_ahead_enabled` profile field (default 1). When off,
+`get_ahead_cards` returns `[]` and the UI never shows the option.
+
+### 2. Session plumbing
+
+`StudySession` (`cardbrick/session.py`) takes an optional `ahead=False`
+flag:
+
+* When `ahead=True`, it seeds its queue from `get_ahead_cards` instead of
+  `get_due_cards`. Everything else — answering, LEARN_AHEAD requeue of
+  learning cards, undo, bury/suspend, summary, session row — is unchanged
+  and works as-is, because answers flow through the same
+  `ReviewService.answer_card` path.
+* The session row records that it was an ahead session (see migration
+  below) so the calendar/stats can distinguish it later if wanted. Ahead
+  sessions still earn a calendar stamp — extra effort should be rewarded,
+  and `sessions_per_day` already counts any session with reviews.
+
+### 3. UI flow (`cardbrick/app.py`)
+
+* `screen_child_start`: when the normal queue is empty **and**
+  `counts_for_ahead_queue` > 0, replace the dead end with:
+
+  * "All done for today! ⭐" (keep the celebration)
+  * "Study ahead: N cards from tomorrow" + "Press the bottom button to
+    keep going!"
+  * Bottom button starts an ahead session (via `DECK_SELECT` when more
+    than one deck is assigned, same as today, with ahead counts shown).
+
+  When the ahead pool is also empty (deck truly exhausted or feature
+  disabled), keep the current "Come back tomorrow." message.
+* `screen_summary`: add a third action — when the normal queue is empty
+  but ahead cards exist, show "… = Study ahead" in the footer and start
+  the next session directly, so a child with momentum never has to bounce
+  through the start screen. (When normal cards remain — e.g. the session
+  ended on the time limit — the existing "Done → start screen → Start"
+  path already covers "go again", so the summary shortcut can offer that
+  too, but that is polish, not core.)
+* A small visual marker during ahead sessions (e.g. "STUDYING AHEAD" in
+  the header where `_draw_review` puts the deck/remaining labels) so the
+  log, the child, and a watching parent all know these are bonus reviews.
+* State passed the same way as the existing deck filter
+  (`self._session_deck_filter`): an `self._session_ahead` flag cleared by
+  `screen_child_start`.
+
+### 4. Parent controls
+
+New profile columns, wired through the existing machinery:
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `study_ahead_enabled` | INTEGER (bool) | 1 | Offer ahead sessions at all |
+| `study_ahead_days` | INTEGER | 1 | How far past midnight the horizon reaches |
+| `study_ahead_extra_new` | INTEGER | 0 | Bonus new cards/day during ahead sessions |
+
+* Schema: add to `CREATE TABLE profiles` and to the ALTER-TABLE migration
+  map (`storage.py` ~line 124–137) with a schema-version bump — the
+  versioned in-place migration path already exists.
+* Add the fields to the two profile-update allowlists
+  (`storage.py:538, :554`) so the profile CLI can set them
+  (`cardbrick-cli`), matching how `session_card_limit` etc. are managed.
+* Parent Mode screens: not required for v1 (parents manage limits via the
+  CLI today); can be added to the parent menu later alongside the other
+  limit editing.
+
+### 5. Tests (`cardbrick-py/tests/test_study_ahead.py`)
+
+Following the house style (injected `now_fn`, log-derived counters):
+
+1. **Pool selection** — `get_ahead_cards` returns only cards with
+   `now < due <= horizon`, soonest first; suspended and buried cards are
+   excluded; deck/category filters apply.
+2. **Horizon** — `study_ahead_days=1` picks up tomorrow's cards but not
+   the day after; `study_ahead_days=2` picks up both.
+3. **Caps** — daily review/new caps exhausted → normal queue empty, ahead
+   queue non-empty; `session_card_limit` still truncates; bonus new cards
+   appear only up to `study_ahead_extra_new` and are counted from the log
+   (undo restores the allowance).
+4. **Gate** — `study_ahead_enabled=0` → empty ahead queue.
+5. **FSRS early review** — answering an ahead card produces a valid state
+   with `due > now` and doesn't reduce reps/stability bookkeeping;
+   answering it Again brings it back within the session (LEARN_AHEAD path
+   unchanged).
+6. **Shrinking pool** — after an ahead session covers the whole horizon,
+   a second ahead session finds (almost) nothing: the loop terminates.
+7. **Session row** — ahead sessions are flagged, still counted by
+   `sessions_per_day`, and `summary()` numbers are correct.
+8. **Regression guard** — mid-day resume with unexhausted caps still
+   works exactly as before (normal queue, no ahead flag).
+
+## Implementation order
+
+Each step lands independently and keeps the suite green:
+
+1. **Storage**: `ahead_candidates` query + profile columns + migration +
+   allowlists (+ tests 1, 2 partially).
+2. **Service**: `get_ahead_cards`, `counts_for_ahead_queue`, bonus-new
+   accounting (+ tests 1–4).
+3. **Session**: `ahead=` flag, session-row flag (+ tests 5–8).
+4. **UI**: start-screen offer, summary shortcut, deck-select counts,
+   review-header marker. Manual smoke on desktop pygame
+   (`cardbrick-py/main.py`) since screens are loop-driven.
+5. **CLI**: expose the three fields in the profile CLI; update
+   `docs/CLI_API.md` / developer guide if they enumerate profile fields.
+
+## Edge cases called out
+
+* **Buried cards** stay excluded from ahead sessions — bury means "not
+  today", and studying ahead must not resurrect them.
+* **Learning-state cards due later today** (rated Again/Hard earlier) fall
+  inside any horizon and are the most valuable content — they come first
+  because ordering is by due date.
+* **Midnight rollover mid-session**: all accounting is log-derived, so an
+  ahead session straddling midnight just means tomorrow starts with those
+  cards already pushed out. No special handling.
+* **Undo** in an ahead session restores state exactly (existing snapshot
+  mechanism) — including the bonus-new allowance, since it's log-derived.
+
+## Out of scope
+
+* **The legacy Rust app** (`src/`). It has the same dead end (the daily
+  queue file in `src/scheduler/queue.rs` is built once per day, and
+  `continue_studying` in `src/scenes/studying/logic.rs` only reshuffles or
+  previews new cards), but its SM-2 scheduler has no sound notion of early
+  review, and active development has moved to `cardbrick-py`. If wanted
+  later, the equivalent would be a separate design (SM-2 needs an
+  elapsed/scheduled interval adjustment for early reviews).
+* Parent Mode screens for the new fields (CLI-only in v1).
+* Any change to points/gamification — `cardbrick-py` has no points
+  system; the stamp calendar already rewards extra sessions.


### PR DESCRIPTION
## Summary

Refactor CardBrick's study model from a single daily queue to a **sprint-based microstudying system** where children chip away at a daily card goal in short 5–10 minute sprints. When the due pool runs dry before the goal is met, sprints are topped up with soon-due cards pulled forward ("studying ahead"), and an optional bonus sprint is offered after the goal is reached.

## Key Changes

### Storage & Migration
- Add three new profile columns: `daily_goal_cards` (default 150), `study_ahead_days` (default 1), `study_ahead_enabled` (default 1)
- Bump schema version to 5 with migration that seeds `daily_goal_cards` from old `daily_review_cards + daily_new_cards` for existing profiles
- Add `ahead_candidates()` query to fetch cards due soon (within the study-ahead horizon) for pull-forward fill
- Add `daily_answer_count()` to track total answers logged today (not unique cards), which drives the goal budget

### Service Layer
- Replace `daily_review_cards` cap with `daily_goal_cards` in queue building; new cards still paced by `daily_new_cards`
- Implement three-stage queue fill: due reviews → new cards → ahead cards (when enabled and budget permits)
- Add `sprint_status()` helper returning `{cards_done, cards_remaining, sprints_remaining, sprints_planned, next_sprint_cards, bonus_cards, goal}` — all derived from the append-only review log
- Update `get_due_cards()` to accept `bonus=True` flag (ignores goal budget for optional bonus sprints after goal is met)
- Update `counts_for_queue()` to support bonus mode

### UI (app.py)
- Reframe `screen_child_start` from "X cards today" to **"N sprints to go"** with progress bar (cards_done / goal)
- Show next sprint size and time estimate
- After goal is met: celebrate and offer bonus sprint if ahead pool is non-empty; only show "Come back tomorrow" when both goal and ahead pool are empty
- Add `_sprint_label` ("Sprint 3/8" or "Bonus sprint") displayed in review header
- Update `screen_review()` to compute and display sprint number
- Pass `bonus=True` to `StudySession` when starting a bonus sprint
- Update `screen_deck_select()` to query counts with bonus flag

### Session & CLI
- Add `bonus` parameter to `StudySession.__init__()` (passed through to queue building)
- Update CLI profile command: retire `--daily-review`, add `--daily-goal`, rename `--session-cards`/`--session-minutes` to `--sprint-cards`/`--sprint-minutes`, add `--study-ahead-days` and `--study-ahead` (on/off)
- Update README with new profile examples and goal/sprint framing

### Tests
- Comprehensive test suite (`test_study_ahead.py`) covering:
  - Sprint accounting: status derives counts from log; partial sprints earn partial credit; undo restores counts
  - Going ahead: back-to-back sprints decrement `sprints_remaining`; caps never block while goal unmet
  - Ahead fill: kicks in when due+new can't fill budget; respects horizon, ordering, suspended/buried exclusion, filters; disabled cleanly
  - FSRS early review: ahead cards get valid state with `due > now`; Again requeues within sprint
  - Bonus sprints: offered after goal met; pool drains across repeated bonus sprints
  - Rollover: answers book to the day logged; tomorrow starts clean
  - Migration: existing profiles get sane `daily_goal_cards`

## Notable Implementation Details

- **Log-derived accounting**: All sprint math (cards_done, remaining, sprints_remaining) derives from the append-only review log, not in-memory counters — correct across undo, crashes, and restarts
- **Partial sprint credit**: Quitting early only banks cards actually answered; remaining count stays honest
- **FSRS-safe early review**: py-fsrs computes next state from elapsed time, so pulling a card

https://claude.ai/code/session_01BpqXQKjiwd3ogsmumtDe2j