### PR TITLE
Count the daily goal in distinct cards, not answers

### DIFF
--- a/cardbrick-py/README.md
+++ b/cardbrick-py/README.md
@@ -293,7 +293,8 @@ operation; it is deliberately not exposed in Parent Mode's on-device UI.
 
 The day is a card goal chipped away in short sprints, not one sitting.
 Per child profile: `daily_goal_cards` (default 150) is the day's goal
-in card answers; each sprint is bounded by `session_card_limit`
+in distinct cards (a card repeating a learning step counts once); each
+sprint is bounded by `session_card_limit`
 (default 20) and `session_time_minutes` (10, 0 = off), so the child
 always knows how many sprints they still owe ("3 sprints to go today").
 Doing sprints back-to-back — "going ahead" — burns the count down just

--- a/cardbrick-py/cardbrick/service.py
+++ b/cardbrick-py/cardbrick/service.py
@@ -83,7 +83,7 @@ class ReviewService:
                       deck_filter=None, limits=None, bonus=False):
         """Build the queue for one sprint.
 
-        The day is a card goal (``daily_goal_cards`` answers) chipped
+        The day is a card goal (``daily_goal_cards`` distinct cards) chipped
         away in short sprints; each call returns the next sprint's
         worth, at most ``session_card_limit`` cards and never more than
         what's left of the goal. Order: due review cards (most overdue
@@ -119,10 +119,10 @@ class ReviewService:
 
         now = self.now()
         day_start = iso(local_day_start(now))
-        new_done, _review_done, _ = self.storage.daily_counts(day_start)
-        answers_done = self.storage.daily_answer_count(day_start)
+        new_done, review_done, _ = self.storage.daily_counts(day_start)
+        cards_done = new_done + review_done  # distinct cards, not answers
         remaining_new = max(limits["daily_new_cards"] - new_done, 0)
-        goal_left = max(limits["daily_goal_cards"] - answers_done, 0)
+        goal_left = max(limits["daily_goal_cards"] - cards_done, 0)
         budget = limits["session_card_limit"] if bonus \
             else min(goal_left, limits["session_card_limit"])
 
@@ -172,7 +172,8 @@ class ReviewService:
         survive restarts, crashes, and undo.
 
         Returns a dict:
-            cards_done         answers logged today
+            cards_done         distinct cards answered today (a card
+                               repeating a learning step counts once)
             goal               daily_goal_cards in effect
             cards_remaining    what's left of the goal
             sprints_planned    ceil(goal / sprint size)
@@ -188,7 +189,9 @@ class ReviewService:
                 if profile.get(key) is not None:
                     limits[key] = profile[key]
         now = self.now()
-        done = self.storage.daily_answer_count(iso(local_day_start(now)))
+        new_done, review_done, _ = self.storage.daily_counts(
+            iso(local_day_start(now)))
+        done = new_done + review_done
         goal = limits["daily_goal_cards"]
         sprint_size = max(limits["session_card_limit"], 1)
         remaining = max(goal - done, 0)

--- a/cardbrick-py/cardbrick/storage.py
+++ b/cardbrick-py/cardbrick/storage.py
@@ -472,18 +472,6 @@ class Storage:
             (day_start_iso,))}
         return len(new_ids), len(all_ids - new_ids), new_ids
 
-    def daily_answer_count(self, day_start_iso):
-        """Total not-undone answers logged since the local day start.
-
-        Unlike daily_counts this counts every answer — including
-        learning-step repeats of the same card — which is the unit of
-        the daily goal ("150 cards a day").
-        """
-        return self.conn.execute(
-            """SELECT COUNT(*) AS n FROM review_log
-               WHERE undone = 0 AND reviewed_at >= ?""",
-            (day_start_iso,)).fetchone()["n"]
-
     def daily_history(self, since_iso):
         """Raw (reviewed_at, was_new, card_id) tuples for progress views."""
         return self.conn.execute(

--- a/cardbrick-py/main.py
+++ b/cardbrick-py/main.py
@@ -83,7 +83,7 @@ def build_parser():
                                help="View or edit the child profile")
     p_profile.add_argument("--name", help="Child's name")
     p_profile.add_argument("--daily-goal", type=int,
-                           help="Daily goal in card answers; done in "
+                           help="Daily goal in distinct cards; done in "
                                 "sprints of --sprint-cards")
     p_profile.add_argument("--daily-new", type=int,
                            help="New cards per day")

--- a/cardbrick-py/tests/test_limits.py
+++ b/cardbrick-py/tests/test_limits.py
@@ -86,19 +86,18 @@ def test_daily_cap_counts_work_already_done_today(storage, service, clock):
     assert len(new_ids) == 4
 
 
-def test_goal_counts_every_answer_not_unique_cards(storage, service, clock):
-    # Two answers on the same card (a learning-step repeat) both count
-    # toward the goal: the contract is "N cards answered", not "N
-    # distinct cards".
+def test_goal_counts_distinct_cards_not_answers(storage, service, clock):
+    # A learning-step repeat is the same card, so it consumes the goal
+    # once: the contract is "N distinct cards", and a hard card that
+    # comes back three times doesn't eat three cards' worth of goal.
     seed_card(storage, service, 1)
     seed_card(storage, service, 2, reps=1,
               due=clock.now() - timedelta(days=1))
     limits = _limits(daily_goal_cards=2, daily_new_cards=10)
     service.answer_card(1, 1)  # Again: the card comes back...
-    service.answer_card(1, 3)  # ...and the repeat is a second answer.
-    # Card 2 is due, but the goal budget is already spent; per-unique-
-    # card accounting would have left room for it.
-    assert service.get_due_cards(limits=limits) == []
+    service.answer_card(1, 3)  # ...but the repeat counts it only once.
+    queue = service.get_due_cards(limits=limits)
+    assert [row["id"] for row in queue] == [2]  # room for one more card
 
 
 def test_daily_budgets_reset_at_local_midnight(storage, service, clock):

--- a/cardbrick-py/tests/test_study_ahead.py
+++ b/cardbrick-py/tests/test_study_ahead.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta
 from conftest import seed_card
 
 from cardbrick.scheduler import iso
-from cardbrick.service import local_day_start
 from cardbrick.session import StudySession
 from cardbrick.storage import Storage
 
@@ -311,9 +310,10 @@ def test_migration_seeds_goal_from_old_caps(tmp_path):
         storage.close()
 
 
-def test_answers_before_day_start_do_not_count(storage, service, clock):
-    day_start = local_day_start(clock.now())
-    assert storage.daily_answer_count(iso(day_start)) == 0
+def test_cards_done_counts_distinct_cards(storage, service, clock):
     seed_card(storage, service, 1)
-    service.answer_card(1, 3)
-    assert storage.daily_answer_count(iso(day_start)) == 1
+    limits = _limits(daily_goal_cards=10, study_ahead_enabled=0)
+    assert service.sprint_status(limits=limits)["cards_done"] == 0
+    service.answer_card(1, 1)  # Again: the card will repeat...
+    service.answer_card(1, 3)  # ...but stays one card toward the goal
+    assert service.sprint_status(limits=limits)["cards_done"] == 1

--- a/docs/STUDYING_AHEAD_PLAN.md
+++ b/docs/STUDYING_AHEAD_PLAN.md
@@ -8,8 +8,8 @@ goal** (say 150 cards) in **5–10 minute sprints** spread across the day.
 
 Two numbers drive everything:
 
-* `daily_goal_cards` — how many card answers the child should log today
-  (parent-set, e.g. 150);
+* `daily_goal_cards` — how many distinct cards the child should answer
+  today (parent-set, e.g. 150);
 * a **sprint** — one `StudySession`, already bounded by
   `session_card_limit` (cards per sitting) and `session_time_minutes`
   (5–10 min).
@@ -18,7 +18,8 @@ From these we derive, always from the append-only review log (never
 in-memory counters, matching the house style):
 
 ```
-cards_done_today   = non-undone review-log entries since local midnight
+cards_done_today   = distinct cards in the non-undone review log since
+                     local midnight (a learning-step repeat counts once)
 cards_remaining    = max(daily_goal_cards - cards_done_today, 0)
 sprints_remaining  = ceil(cards_remaining / session_card_limit)
 sprints_planned    = ceil(daily_goal_cards / session_card_limit)
@@ -59,8 +60,8 @@ dry before the goal is met.
 `daily_review_cards` in the queue math (`get_due_cards`):
 
 * `remaining_review = max(daily_goal_cards - cards_done_today, 0)` —
-  answers, not unique cards: learning-step repeats within a sprint count
-  toward the goal, which is correct for a "150 cards a day" contract.
+  distinct cards, not answers: a hard card repeating its learning steps
+  within a sprint counts toward "150 cards a day" once.
 * `daily_new_cards` keeps its current meaning — it paces how fast new
   material enters FSRS, which is orthogonal to the goal.
 * `daily_review_cards` is retired from queue-building (column stays for
@@ -140,7 +141,7 @@ allowlists (`storage.py:538, :554`) so the profile CLI can set them:
 
 | Field | Type | Default | Meaning |
 |---|---|---|---|
-| `daily_goal_cards` | INTEGER | 150 | Card answers per day; drives sprint count |
+| `daily_goal_cards` | INTEGER | 150 | Distinct cards per day; drives sprint count |
 | `study_ahead_days` | INTEGER | 1 | How far forward the ahead fill may reach |
 | `study_ahead_enabled` | INTEGER (bool) | 1 | Allow ahead fill + bonus sprints |
 


### PR DESCRIPTION
Follow-up to #20: the daily goal (`daily_goal_cards`) now counts **distinct cards** answered today instead of total answers.

## What changed

- A hard card rated Again that cycles through its learning steps consumes the goal **once**, no matter how many times it comes back — struggling can no longer inflate progress toward "150 cards a day".
- `cards_done` (used by the sprint budget in `get_due_cards` and by `sprint_status`) is now derived from the existing distinct-card `daily_counts`; the `daily_answer_count` query added in #20 is deleted.
- Docstrings, README, CLI help, and the plan doc updated to say "distinct cards".
- `test_goal_counts_distinct_cards_not_answers` proves a learning-step repeat leaves room in the goal budget for another due card; `test_cards_done_counts_distinct_cards` pins the `sprint_status` side.

## Verification

- Full suite: 157 passed, 1 skipped
- `ruff check cardbrick-py/` clean
- Headless end-to-end drive of the pygame UI (two goal sprints back-to-back → bonus sprint → all-done screen) still passes with the expected session/card counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpqXQKjiwd3ogsmumtDe2j

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpqXQKjiwd3ogsmumtDe2j)_