### PR TITLE
Add WiFi deck download support with server manifest

### DIFF
--- a/cardbrick-py/README.md
+++ b/cardbrick-py/README.md
@@ -12,7 +12,8 @@ is done. Parents configure everything else in a separate parent mode.
 The objective is *not* to recreate Anki. Anki's `.apkg` files are used
 as a **content format only** — after a one-time import, the application
 runs entirely from its own SQLite database with no Anki desktop, no
-AnkiConnect, no Rust backend, and no network access.
+AnkiConnect, no Rust backend, and no network access during study (the
+network is touched only by the optional parent-mode deck download).
 
 ## Architecture
 
@@ -91,8 +92,14 @@ exact player with `CARDBRICK_AUDIO_CMD="mpg123 -q {file}"`.
 pip install -r requirements.txt
 
 # One-time import (repeatable; progress is preserved). Also available
-# inside the app's parent mode.
+# inside the app's parent mode. A file path or an http(s) URL.
 python main.py import MyDeck.apkg
+python main.py import http://192.168.1.10:8000/MyDeck.apkg
+
+# Download decks from a server into the data folder's import/
+# directory without importing them (see "Downloading decks over WiFi")
+python main.py download http://192.168.1.10:8000/decks.json --list
+python main.py download                # uses the deck_server_url setting
 
 # The study appliance (child/parent flow) — this is the default command
 python main.py study                  # add --fullscreen on the handheld
@@ -226,7 +233,8 @@ of updating the old one's progress.
 ### Parent mode
 
 `SELECT` on the start screen. From there: import `.apkg` files found in
-the data folder (or `data/import/`, or the app folder), choose active
+the data folder (or `data/import/`, or the app folder), download decks
+from a configured server over WiFi (see below), choose active
 **decks** (which imported decks are *assigned* to the child at all)
 and active **categories** (Anki tags — a second, independent filter;
 both must match for a card to appear), set daily limits, review/restore
@@ -244,6 +252,47 @@ python main.py profile --decks "Español de México — Vocabulario"
 python main.py profile --decks all           # clear the deck filter
 python main.py profile --categories restaurant,greetings
 ```
+
+### Downloading decks over WiFi
+
+Getting an `.apkg` onto the device normally means pulling the SD card
+or setting up SSH. Instead, a parent can host decks on any plain
+HTTP(S) server — `python -m http.server` in a folder on the family PC,
+a NAS, nginx, a static bucket — and point the device at it once, in
+`settings.json` in the data folder:
+
+```json
+"deck_server_url": "http://192.168.1.10:8000/decks.json"
+```
+
+The URL is either a direct link to one `.apkg`, or a JSON deck list:
+
+```json
+{
+  "decks": [
+    {"name": "Español N5", "file": "n5.apkg", "size": 52428800},
+    {"name": "Español N4", "url": "http://elsewhere/n4.apkg"}
+  ]
+}
+```
+
+`file`/`url` may be relative to the deck list's own URL, so a
+`decks.json` can simply sit in the same folder as the decks it lists
+(`size` in bytes and `name` are optional, shown in the UI). Parent
+mode's **Download decks (WiFi)** screen then lists what the server
+offers; picking one downloads it with a progress readout and imports
+it immediately. The same plumbing is available from the CLI as
+`python main.py download` (fetch only, into `data/import/`) and
+`python main.py import <url>` (fetch + import).
+
+Everything uses the standard library (`urllib`) — no new dependencies.
+Downloads are streamed to a `.part` file, capped at 1 GiB, verified to
+be a real zip archive, and only then renamed into place, so a dropped
+connection or a captive-portal page never leaves a corrupt `.apkg`
+behind; only `http://`/`https://` URLs are followed, redirects
+included. There is deliberately no on-device URL keyboard — the URL is
+a set-once setting edited on the SD card, in keeping with
+`settings.json` being "durable and user-editable on purpose."
 
 ### Child-facing deck picker
 

--- a/cardbrick-py/cardbrick/app.py
+++ b/cardbrick-py/cardbrick/app.py
@@ -9,8 +9,8 @@ day (see ReviewService.sprint_status), never one long sitting. Screens:
                  -> Review again ("going ahead": the next sprint now)
                  -> or back to ChildStart
     ChildStart / SessionSummary -> Calendar (stamp calendar) -> back
-    ChildStart -> ParentMode (import / decks / categories / limits /
-                              suspended / progress / calendar /
+    ChildStart -> ParentMode (import / download / decks / categories /
+                              limits / suspended / progress / calendar /
                               controller setup) -> ChildStart
 
 Parent Mode's Decks screen configures which decks are *assigned* to the
@@ -286,6 +286,7 @@ class CardBrickApp:
             "CALENDAR": self.screen_calendar,
             "PARENT_MENU": self.screen_parent_menu,
             "PARENT_IMPORT": self.screen_parent_import,
+            "PARENT_DOWNLOAD": self.screen_parent_download,
             "PARENT_CATEGORIES": self.screen_parent_categories,
             "PARENT_DECKS": self.screen_parent_decks,
             "PARENT_LIMITS": self.screen_parent_limits,
@@ -1055,6 +1056,7 @@ class CardBrickApp:
         direction = self.profile.get("study_direction", "normal")
         entries = [
             ("Import deck (.apkg)", "PARENT_IMPORT"),
+            ("Download decks (WiFi)", "PARENT_DOWNLOAD"),
             ("Decks", "PARENT_DECKS"),
             ("Categories", "PARENT_CATEGORIES"),
             ("Daily goal & sprints", "PARENT_LIMITS"),
@@ -1193,6 +1195,111 @@ class CardBrickApp:
                 self._center(self.font_small.render(line, True, WARN), y)
                 y += 24
         self._footer("Bottom = Import   Right = Back")
+
+    def screen_parent_download(self):
+        """Fetch the deck list from the configured server, download the
+        chosen deck into the import folder, and import it right away.
+        Network calls block the loop like importing does — a redraw
+        callback keeps a progress line moving during the transfer."""
+        from .deck_download import (DownloadError, download_deck,
+                                    fetch_deck_list, format_size)
+        server_url = (self.settings.get("deck_server_url") or "").strip()
+        dest_dir = self.paths.import_dir if self.paths else \
+            os.path.join(self.settings_dir(), "import")
+
+        decks, message = [], None
+        if not server_url:
+            message = ('No server set. Add "deck_server_url" to '
+                       'settings.json in the data folder on the SD '
+                       'card, e.g. "http://192.168.1.10:8000/decks.json"')
+        else:
+            self._draw_download([], 0, f"Connecting to {server_url} …",
+                                server_url)
+            self.present()
+            try:
+                decks = fetch_deck_list(server_url)
+            except DownloadError as exc:
+                message = str(exc)
+                log.error("deck list from %s failed: %s", server_url, exc)
+
+        index = 0
+        while True:
+            action = self.poll()
+            if action in ("start", "east_button", "select"):
+                return "PARENT_MENU"
+            if decks and action == "dpad_up":
+                index = (index - 1) % len(decks)
+            elif decks and action == "dpad_down":
+                index = (index + 1) % len(decks)
+            elif decks and action == "south_button":
+                entry = decks[index]
+                last_drawn = [0.0]
+
+                def progress(received, total):
+                    if time.time() - last_drawn[0] < 0.1:
+                        return
+                    last_drawn[0] = time.time()
+                    if total:
+                        note = f"{received * 100 // total}% of " \
+                               f"{format_size(total)}"
+                    else:
+                        note = format_size(received)
+                    self._draw_download(decks, index,
+                                        f"Downloading {entry['name']} … "
+                                        f"{note}", server_url)
+                    self.present()
+                    pygame.event.pump()  # keep the window responsive
+
+                self._draw_download(decks, index,
+                                    f"Downloading {entry['name']} …",
+                                    server_url)
+                self.present()
+                try:
+                    path = download_deck(entry["url"], dest_dir,
+                                         progress=progress,
+                                         name=entry["name"])
+                    self._draw_download(decks, index, "Importing …",
+                                        server_url)
+                    self.present()
+                    stats = import_apkg(
+                        path, self.storage, self.service.scheduler,
+                        os.path.join(self.settings_dir(), "media"))
+                    message = stats.summary()
+                    log.info("download+import %s: %s", entry["url"],
+                             message)
+                except (DownloadError, ApkgError, OSError) as exc:
+                    message = f"Failed: {exc}"
+                    log.error("download %s failed: %s", entry["url"], exc)
+
+            self._draw_download(decks, index, message, server_url)
+            self.present()
+            self.clock.tick(FPS)
+
+    def _draw_download(self, decks, index, message, server_url=None):
+        from .deck_download import format_size
+        self.screen.fill(BG)
+        self._center(self.font_big.render("Download Decks", True, FG), 40)
+        if server_url:
+            self._center(self.font_small.render(server_url, True, DIM), 90)
+        if decks:
+            visible = 6
+            top = min(max(0, index - visible + 1), index)
+            y = 116
+            for i in range(top, min(top + visible, len(decks))):
+                entry = decks[i]
+                color = ACCENT if i == index else FG
+                prefix = "> " if i == index else "   "
+                size = format_size(entry["size"])
+                label = entry["name"] + (f"  ({size})" if size else "")
+                self.screen.blit(self.font.render(prefix + label, True,
+                                                  color), (70, y))
+                y += 38
+        if message:
+            y = self.h - 170
+            for line in wrap_text(self.font_small, message, self.w - 80):
+                self._center(self.font_small.render(line, True, WARN), y)
+                y += 24
+        self._footer("Bottom = Download + Import   Right = Back")
 
     def screen_parent_categories(self):
         return self._screen_multi_select(

--- a/cardbrick-py/cardbrick/deck_download.py
+++ b/cardbrick-py/cardbrick/deck_download.py
@@ -1,0 +1,239 @@
+"""Download .apkg decks from a server URL — standard library only.
+
+A parent hosts decks on any plain HTTP(S) server (nginx, a NAS,
+`python -m http.server` on the family PC, an S3 bucket, ...); the
+device downloads them over WiFi into the import folder, where the
+existing importer takes over. No new dependencies: `urllib.request`
+does the transfer, `json` reads the deck list, `zipfile` sanity-checks
+the result.
+
+The configured URL may point at either:
+
+* a single deck: any URL whose path ends in ``.apkg``, or
+* a deck list (manifest): a JSON document, either
+  ``{"decks": [{"name": "...", "url": "n5.apkg", "size": 12345}, ...]}``
+  or a bare list of the same entry objects. ``url`` (or the alias
+  ``file``) may be relative — it is resolved against the manifest's own
+  URL, so a manifest can sit in the same folder as its decks. ``name``
+  and ``size`` are optional; ``size`` is bytes, shown in the UI.
+
+Downloads are hardened for an unattended appliance:
+
+* http/https only — including across redirects (the default urllib
+  opener would happily follow a redirect to ``file://``).
+* Streamed to ``<name>.part`` with a byte cap, verified to be a real
+  zip archive, then atomically renamed — a dropped WiFi connection or
+  a captive-portal HTML page never leaves a plausible-looking .apkg.
+* Filenames are reduced to a safe basename; a hostile manifest cannot
+  write outside the destination folder.
+"""
+
+import json
+import logging
+import os
+import posixpath
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30  # seconds; per socket operation, not the whole file
+DEFAULT_MAX_BYTES = 1024 * 1024 * 1024  # 1 GiB sanity cap
+CHUNK_SIZE = 64 * 1024
+USER_AGENT = "CardBrick"
+
+ALLOWED_SCHEMES = ("http", "https")
+
+
+class DownloadError(Exception):
+    """Anything that should surface as a friendly message, not a crash."""
+
+
+def _build_opener():
+    """An opener that speaks *only* http/https, even after redirects.
+
+    urllib's default opener chain includes file:// and ftp:// handlers,
+    and a redirect can switch schemes — so build the chain explicitly.
+    """
+    opener = urllib.request.OpenerDirector()
+    for handler in (urllib.request.HTTPHandler(),
+                    urllib.request.HTTPSHandler(),
+                    urllib.request.HTTPDefaultErrorHandler(),
+                    urllib.request.HTTPRedirectHandler(),
+                    urllib.request.HTTPErrorProcessor(),
+                    urllib.request.UnknownHandler()):
+        opener.add_handler(handler)
+    return opener
+
+
+_opener = _build_opener()
+
+
+def _open(url, timeout):
+    scheme = urllib.parse.urlsplit(url).scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        raise DownloadError(f"Only http:// and https:// URLs are "
+                            f"supported (got {scheme or 'no scheme'}).")
+    request = urllib.request.Request(url,
+                                     headers={"User-Agent": USER_AGENT})
+    try:
+        return _opener.open(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        raise DownloadError(f"Server said {exc.code} {exc.reason} "
+                            f"for {url}") from exc
+    except urllib.error.URLError as exc:
+        raise DownloadError(f"Cannot reach {url}: {exc.reason}") from exc
+    except (OSError, ValueError) as exc:
+        raise DownloadError(f"Cannot reach {url}: {exc}") from exc
+
+
+def _is_apkg_url(url):
+    path = urllib.parse.urlsplit(url).path
+    return path.lower().endswith(".apkg")
+
+
+def safe_filename(url, name=None):
+    """A bare .apkg filename for a download, from the entry name or the
+    URL path — never anything that can escape the destination folder."""
+    candidate = name or ""
+    if not candidate:
+        path = urllib.parse.urlsplit(url).path
+        candidate = urllib.parse.unquote(posixpath.basename(path))
+    # Basename twice over both separator styles, then whitelist chars.
+    candidate = os.path.basename(candidate.replace("\\", "/"))
+    candidate = re.sub(r"[^\w.\- ()]", "_", candidate).strip(". ")
+    if candidate.lower().endswith(".apkg"):
+        candidate = candidate[:-len(".apkg")].strip(". ")
+    if not candidate:
+        candidate = "deck"
+    return candidate + ".apkg"
+
+
+def fetch_deck_list(server_url, timeout=DEFAULT_TIMEOUT):
+    """The decks offered at server_url, normalised to
+    ``[{"name", "url", "size"}, ...]``.
+
+    A direct .apkg URL yields a single-entry list; anything else is
+    fetched and parsed as a JSON manifest (see module docstring).
+    """
+    server_url = server_url.strip()
+    if not server_url:
+        raise DownloadError("No server URL configured.")
+    if _is_apkg_url(server_url):
+        return [{"name": safe_filename(server_url), "url": server_url,
+                 "size": None}]
+
+    with _open(server_url, timeout) as response:
+        raw = response.read(4 * 1024 * 1024)  # a manifest is small
+        manifest_url = response.geturl()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DownloadError(
+            f"{server_url} is not a deck list: expected JSON like "
+            f'{{"decks": [{{"name": ..., "url": ...}}]}} or a direct '
+            f"link to an .apkg file ({exc}).") from exc
+
+    entries = data.get("decks") if isinstance(data, dict) else data
+    if not isinstance(entries, list):
+        raise DownloadError(f"{server_url}: JSON must be a list of decks "
+                            f'or an object with a "decks" list.')
+
+    decks = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        url = entry.get("url") or entry.get("file")
+        if not url or not isinstance(url, str):
+            continue
+        url = urllib.parse.urljoin(manifest_url, url)
+        if urllib.parse.urlsplit(url).scheme.lower() not in ALLOWED_SCHEMES:
+            log.warning("deck list entry skipped (bad scheme): %r", url)
+            continue
+        name = entry.get("name")
+        name = name.strip() if isinstance(name, str) else ""
+        size = entry.get("size")
+        if not isinstance(size, int) or size < 0:
+            size = None
+        decks.append({"name": name or safe_filename(url),
+                      "url": url, "size": size})
+    if not decks:
+        raise DownloadError(f"The deck list at {server_url} has no "
+                            f"usable decks.")
+    return decks
+
+
+def download_deck(url, dest_dir, timeout=DEFAULT_TIMEOUT,
+                  max_bytes=DEFAULT_MAX_BYTES, progress=None, name=None):
+    """Download one .apkg into dest_dir; returns the final path.
+
+    progress, if given, is called as progress(received_bytes,
+    total_bytes_or_None) roughly once per chunk. The file appears at
+    its final name only after it downloaded completely and proved to
+    be a real zip archive.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    final_path = os.path.join(dest_dir, safe_filename(url, name))
+    part_path = final_path + ".part"
+
+    with _open(url, timeout) as response:
+        total = response.headers.get("Content-Length")
+        try:
+            total = int(total) if total is not None else None
+        except ValueError:
+            total = None
+        if total is not None and total > max_bytes:
+            raise DownloadError(
+                f"Deck is {total // (1024 * 1024)} MB — larger than the "
+                f"{max_bytes // (1024 * 1024)} MB limit.")
+
+        received = 0
+        try:
+            with open(part_path, "wb") as out:
+                while True:
+                    try:
+                        chunk = response.read(CHUNK_SIZE)
+                    except OSError as exc:
+                        raise DownloadError(
+                            f"Connection lost after "
+                            f"{received // 1024} kB: {exc}") from exc
+                    if not chunk:
+                        break
+                    received += len(chunk)
+                    if received > max_bytes:
+                        raise DownloadError(
+                            f"Download exceeded the "
+                            f"{max_bytes // (1024 * 1024)} MB limit.")
+                    out.write(chunk)
+                    if progress:
+                        progress(received, total)
+            if total is not None and received < total:
+                raise DownloadError(f"Connection closed early: got "
+                                    f"{received} of {total} bytes.")
+            if not zipfile.is_zipfile(part_path):
+                raise DownloadError(
+                    "The server did not send an .apkg file (got "
+                    "something that is not a zip archive — a login or "
+                    "error page, perhaps).")
+            os.replace(part_path, final_path)
+        finally:
+            if os.path.exists(part_path):
+                try:
+                    os.remove(part_path)
+                except OSError:
+                    log.warning("could not remove %s", part_path)
+
+    log.info("downloaded %s (%d bytes) -> %s", url, received, final_path)
+    return final_path
+
+
+def format_size(size):
+    """'12.3 MB' style label for the UI; '' when size is unknown."""
+    if size is None:
+        return ""
+    if size < 1024 * 1024:
+        return f"{max(size, 1) // 1024 or 1} kB"
+    return f"{size / (1024 * 1024):.1f} MB"

--- a/cardbrick-py/cardbrick/settings.py
+++ b/cardbrick-py/cardbrick/settings.py
@@ -13,6 +13,9 @@ log = logging.getLogger(__name__)
 DEFAULTS = {
     "current_child_profile_id": None,
     "auto_play_audio": True,
+    # http(s) URL of a deck server: either a direct link to an .apkg or
+    # a JSON deck list — see cardbrick/deck_download.py for the format.
+    "deck_server_url": None,
     "fullscreen": False,
     "logical_width": 640,
     "logical_height": 480,

--- a/cardbrick-py/main.py
+++ b/cardbrick-py/main.py
@@ -4,7 +4,12 @@
 Usage:
     python main.py study [--fullscreen]     CardBrick-style study appliance
                                             (child/parent flow; the default)
-    python main.py import <deck.apkg>       Import an Anki package
+    python main.py import <deck.apkg|URL>   Import an Anki package (a
+                                            file path or an http(s) URL)
+    python main.py download [URL]           Download decks from a server
+                                            (URL or deck_server_url
+                                            setting) into the import
+                                            folder
     python main.py review [--deck NAME]     Legacy prototype reviewer
     python main.py decks                    List decks and due counts
     python main.py profile [...]            View/edit the child profile
@@ -61,8 +66,10 @@ def build_parser():
 
     p_import = sub.add_parser(
         "import", help="Import an .apkg file, or a vocab .csv "
-                       "(detected by extension)")
-    p_import.add_argument("apkg", help="Path to the .apkg or .csv file")
+                       "(detected by extension); .apkg may also be an "
+                       "http(s) URL, downloaded before import")
+    p_import.add_argument("apkg", help="Path or http(s) URL of the "
+                                       ".apkg (or path of a .csv) file")
     p_import.add_argument("--media-dir",
                           help="For .csv import: folder holding the audio/"
                                "image files it references, copied into "
@@ -70,6 +77,20 @@ def build_parser():
     p_import.add_argument("--deck", dest="import_deck",
                           help="For .csv import: deck name to file the "
                                "cards under (default: Vocabulario)")
+
+    p_download = sub.add_parser(
+        "download", help="Download decks from a server URL into the "
+                         "import folder (does not import them)")
+    p_download.add_argument("url", nargs="?", default=None,
+                            help="Deck URL or JSON deck-list URL "
+                                 "(default: the deck_server_url "
+                                 "setting)")
+    p_download.add_argument("--deck", action="append", dest="decks",
+                            metavar="NAME",
+                            help="Only download this deck from the "
+                                 "list (repeatable; default: all)")
+    p_download.add_argument("--list", action="store_true", dest="list_only",
+                            help="Show what the server offers and exit")
 
     p_review = sub.add_parser("review",
                               help="Legacy prototype reviewer (no limits)")
@@ -167,6 +188,15 @@ def main(argv=None):
             return _run_app(storage, scheduler, paths,
                             fullscreen=False, initial_state="INPUT_DIAG")
         if args.command == "import":
+            if args.apkg.lower().startswith(("http://", "https://")):
+                from cardbrick.deck_download import (DownloadError,
+                                                     download_deck)
+                try:
+                    args.apkg = download_deck(args.apkg, paths.import_dir)
+                except DownloadError as exc:
+                    print(f"Download failed: {exc}", file=sys.stderr)
+                    return 1
+                print(f"Downloaded to {args.apkg}")
             if args.apkg.lower().endswith(".csv"):
                 from cardbrick.vocab_csv import import_vocab_csv
                 kwargs = {"source_media_dir": args.media_dir}
@@ -178,6 +208,10 @@ def main(argv=None):
                 stats = import_apkg(args.apkg, storage, scheduler,
                                     paths.media_dir)
             print(stats.summary())
+        elif args.command == "download":
+            from cardbrick.settings import AppSettings
+            settings = AppSettings(paths.settings_path)
+            return _download_command(settings, paths, args)
         elif args.command == "decks":
             rows = storage.decks(iso(now_utc()))
             if not rows:
@@ -251,6 +285,59 @@ def _run_app(storage, scheduler, paths, fullscreen=None,
                                       "Restart the app to continue.")
         return 1
     return 0
+
+
+def _download_command(settings, paths, args):
+    """Fetch the server's deck list and download into the import
+    folder, where both `main.py import` and the parent-mode Import
+    screen will find the files."""
+    from cardbrick.deck_download import (DownloadError, download_deck,
+                                         fetch_deck_list, format_size)
+
+    url = args.url or settings.get("deck_server_url")
+    if not url:
+        print("No URL given and no deck_server_url setting configured.\n"
+              f"Either pass a URL or add \"deck_server_url\" to "
+              f"{paths.settings_path}", file=sys.stderr)
+        return 1
+
+    try:
+        decks = fetch_deck_list(url)
+    except DownloadError as exc:
+        print(f"Download failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.list_only:
+        for deck in decks:
+            size = format_size(deck["size"])
+            print(f"{deck['name']}{f'  ({size})' if size else ''}  "
+                  f"-> {deck['url']}")
+        return 0
+
+    wanted = decks
+    if args.decks:
+        by_name = {d["name"]: d for d in decks}
+        missing = [n for n in args.decks if n not in by_name]
+        if missing:
+            print(f"Not on the server: {', '.join(missing)}\n"
+                  f"Available: {', '.join(by_name)}", file=sys.stderr)
+            return 1
+        wanted = [by_name[n] for n in args.decks]
+
+    failures = 0
+    for deck in wanted:
+        print(f"Downloading {deck['name']}...")
+        try:
+            path = download_deck(deck["url"], paths.import_dir,
+                                 name=deck["name"])
+            print(f"  -> {path}")
+        except DownloadError as exc:
+            failures += 1
+            print(f"  failed: {exc}", file=sys.stderr)
+    if failures == 0:
+        print(f"Done. Import with: python main.py import <file>, or use "
+              f"the parent-mode Import screen.")
+    return 1 if failures else 0
 
 
 def _profile_command(storage, args):

--- a/cardbrick-py/tests/test_deck_download.py
+++ b/cardbrick-py/tests/test_deck_download.py
@@ -1,0 +1,199 @@
+"""Tests for deck_download.py against a real local HTTP server."""
+
+import http.server
+import json
+import os
+import threading
+import zipfile
+
+import pytest
+
+from cardbrick.deck_download import (DownloadError, download_deck,
+                                     fetch_deck_list, format_size,
+                                     safe_filename)
+
+
+@pytest.fixture
+def server(tmp_path):
+    """Serve tmp_path/www on an ephemeral localhost port."""
+    www = tmp_path / "www"
+    www.mkdir()
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(www), **kwargs)
+
+        def log_message(self, *args):
+            pass
+
+    class QuietServer(http.server.ThreadingHTTPServer):
+        def handle_error(self, request, client_address):
+            pass  # client aborts (size-cap test) are expected
+
+    httpd = QuietServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    yield www, base
+    httpd.shutdown()
+    thread.join()
+
+
+def make_apkg(path, payload=b"x" * 1000):
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("collection.anki21", payload)
+    return path
+
+
+# -- fetch_deck_list -------------------------------------------------------------
+
+
+def test_direct_apkg_url_is_a_single_entry_list():
+    decks = fetch_deck_list("http://example.com/decks/JLPT%20N5.apkg")
+    assert decks == [{"name": "JLPT N5.apkg",
+                      "url": "http://example.com/decks/JLPT%20N5.apkg",
+                      "size": None}]
+
+
+def test_manifest_with_decks_object_and_relative_urls(server):
+    www, base = server
+    (www / "decks.json").write_text(json.dumps({"decks": [
+        {"name": "Spanish N5", "file": "n5.apkg", "size": 1234},
+        {"name": "Spanish N4", "url": f"{base}/other/n4.apkg"},
+    ]}))
+    decks = fetch_deck_list(f"{base}/decks.json")
+    assert decks == [
+        {"name": "Spanish N5", "url": f"{base}/n5.apkg", "size": 1234},
+        {"name": "Spanish N4", "url": f"{base}/other/n4.apkg",
+         "size": None},
+    ]
+
+
+def test_manifest_bare_list_and_missing_names(server):
+    www, base = server
+    (www / "decks.json").write_text(json.dumps([
+        {"url": "vocab.apkg", "size": -5},
+    ]))
+    decks = fetch_deck_list(f"{base}/decks.json")
+    assert decks == [{"name": "vocab.apkg", "url": f"{base}/vocab.apkg",
+                      "size": None}]
+
+
+def test_manifest_skips_unusable_entries(server):
+    www, base = server
+    (www / "decks.json").write_text(json.dumps({"decks": [
+        "not-a-dict",
+        {"name": "no url at all"},
+        {"name": "evil", "url": "file:///etc/passwd"},
+        {"name": "ok", "url": "good.apkg"},
+    ]}))
+    decks = fetch_deck_list(f"{base}/decks.json")
+    assert [d["name"] for d in decks] == ["ok"]
+
+
+def test_manifest_with_no_usable_decks_is_an_error(server):
+    www, base = server
+    (www / "decks.json").write_text("[]")
+    with pytest.raises(DownloadError, match="no.*usable decks"):
+        fetch_deck_list(f"{base}/decks.json")
+
+
+def test_non_json_manifest_is_a_friendly_error(server):
+    www, base = server
+    (www / "decks.json").write_text("<html>login page</html>")
+    with pytest.raises(DownloadError, match="not a deck list"):
+        fetch_deck_list(f"{base}/decks.json")
+
+
+def test_missing_manifest_reports_http_status(server):
+    _www, base = server
+    with pytest.raises(DownloadError, match="404"):
+        fetch_deck_list(f"{base}/nope.json")
+
+
+def test_unreachable_server_is_a_download_error():
+    # RFC 5737 TEST-NET address; nothing listens there.
+    with pytest.raises(DownloadError):
+        fetch_deck_list("http://192.0.2.1:9/decks.json", timeout=0.2)
+
+
+def test_empty_and_non_http_urls_are_rejected():
+    with pytest.raises(DownloadError):
+        fetch_deck_list("")
+    with pytest.raises(DownloadError, match="http"):
+        fetch_deck_list("ftp://example.com/decks.json")
+    with pytest.raises(DownloadError, match="http"):
+        download_deck("file:///etc/passwd", "/tmp/never-used")
+
+
+# -- download_deck ---------------------------------------------------------------
+
+
+def test_download_success(server, tmp_path):
+    www, base = server
+    make_apkg(www / "n5.apkg")
+    dest = tmp_path / "import"
+
+    seen = []
+    path = download_deck(f"{base}/n5.apkg", str(dest),
+                         progress=lambda got, total: seen.append((got,
+                                                                  total)))
+    assert os.path.basename(path) == "n5.apkg"
+    assert zipfile.is_zipfile(path)
+    assert seen and seen[-1][0] == os.path.getsize(path)
+    assert seen[-1][1] == os.path.getsize(path)  # Content-Length passed
+    assert os.listdir(dest) == ["n5.apkg"]  # no .part left behind
+
+
+def test_download_uses_entry_name_for_the_filename(server, tmp_path):
+    www, base = server
+    make_apkg(www / "x.apkg")
+    path = download_deck(f"{base}/x.apkg", str(tmp_path),
+                         name="JLPT N5 Vocab")
+    assert os.path.basename(path) == "JLPT N5 Vocab.apkg"
+
+
+def test_download_rejects_non_zip(server, tmp_path):
+    www, base = server
+    (www / "fake.apkg").write_text("<html>captive portal</html>")
+    dest = tmp_path / "import"
+    with pytest.raises(DownloadError, match="not a zip"):
+        download_deck(f"{base}/fake.apkg", str(dest))
+    assert os.listdir(dest) == []  # nothing plausible left behind
+
+
+def test_download_enforces_size_cap(server, tmp_path):
+    www, base = server
+    make_apkg(www / "big.apkg", payload=os.urandom(300_000))
+    dest = tmp_path / "import"
+    with pytest.raises(DownloadError, match="limit"):
+        download_deck(f"{base}/big.apkg", str(dest),
+                      max_bytes=100_000)
+    assert os.listdir(dest) == []
+
+
+def test_download_404(server, tmp_path):
+    _www, base = server
+    with pytest.raises(DownloadError, match="404"):
+        download_deck(f"{base}/missing.apkg", str(tmp_path))
+
+
+# -- helpers ---------------------------------------------------------------------
+
+
+def test_safe_filename_neutralises_hostile_names():
+    url = "http://x/decks/n5.apkg"
+    assert safe_filename(url) == "n5.apkg"
+    assert safe_filename(url, name="../../etc/passwd") == "passwd.apkg"
+    assert safe_filename(url, name="..\\..\\evil") == "evil.apkg"
+    assert safe_filename(url, name="...") == "deck.apkg"
+    assert safe_filename("http://x/", name="") == "deck.apkg"
+    assert safe_filename("http://x/a%20b.apkg") == "a b.apkg"
+    assert safe_filename(url, name="My Deck.apkg") == "My Deck.apkg"
+
+
+def test_format_size():
+    assert format_size(None) == ""
+    assert format_size(500) == "1 kB"
+    assert format_size(200 * 1024) == "200 kB"
+    assert format_size(5 * 1024 * 1024) == "5.0 MB"


### PR DESCRIPTION
## Summary

Add optional WiFi-based deck downloading for the parent-mode appliance, allowing decks to be hosted on any plain HTTP(S) server and downloaded directly into the import folder without requiring SD card access or SSH.

## Key Changes

- **New `deck_download.py` module**: Implements secure, hardened deck downloading with:
  - Support for both direct `.apkg` URLs and JSON deck manifests
  - Streamed downloads to `.part` files with byte-cap enforcement (1 GiB default)
  - Zip archive validation before atomic rename to prevent corrupt files from dropped connections or captive portals
  - Scheme-restricted urllib opener (http/https only, even across redirects)
  - Safe filename sanitization to prevent directory traversal attacks
  - Standard library only (`urllib`, `json`, `zipfile`)

- **Parent-mode UI**: New "Download decks (WiFi)" screen in `app.py`:
  - Fetches and displays available decks from configured server
  - Shows deck names and sizes with live download progress
  - Automatically imports downloaded decks
  - Graceful error handling for network failures

- **CLI support**: New `python main.py download` command:
  - Fetch-only mode (no import) into `data/import/`
  - `--list` flag to preview available decks
  - `--deck NAME` to selectively download specific decks
  - Uses `deck_server_url` setting as default

- **Import enhancement**: `python main.py import` now accepts http(s) URLs in addition to file paths

- **Configuration**: New `deck_server_url` setting in `settings.json` for the server endpoint (either direct `.apkg` or JSON manifest URL)

- **Documentation**: Updated README with deck download workflow, manifest format, and security model

## Implementation Details

- Manifest format supports both `{"decks": [...]}` and bare list syntax
- Relative URLs in manifests are resolved against the manifest's own URL
- Downloads include Content-Length header parsing for progress reporting
- Connection loss detection via early-close and byte-count mismatch
- Filenames derived from manifest `name` field or URL path, with hostile characters neutralized
- Progress callback throttled to ~100ms intervals to avoid excessive UI redraws
- All network errors converted to user-friendly `DownloadError` exceptions

https://claude.ai/code/session_01JUC6t25ShAwWjEeKK1fvvt