### PR TITLE
Add Knulli/RG35XX SP packaging with pygame-ce squashfs runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ test_cache/
 CLAUDE.md
 venv-syncd
 workspace
+
+# Knulli packaging outputs (deploy/knulli)
+deploy/knulli/dist/
+deploy/knulli/runtime-build/build/

--- a/deploy/knulli/CardBrick.sh
+++ b/deploy/knulli/CardBrick.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# CardBrick — Knulli / RG35XX SP launch script (pygame-ce squashfs runtime).
+#
+# Lives at /userdata/roms/ports/CardBrick.sh next to the CardBrick/
+# folder (see PACKAGING.md). Knulli's Ports menu runs it as root.
+# Runtime model derived from https://github.com/viniciusfs/pygame-ce-runtime:
+# a self-contained ARM64 Python venv in a squashfs image is loop-mounted,
+# and the app runs on that interpreter. pygame-ce inside the runtime is
+# linked against the FIRMWARE's SDL2, so Knulli's mali/kmsdrm video
+# drivers work.
+#
+# Usage (also over SSH):
+#   ./CardBrick.sh                    # normal launch: study, fullscreen
+#   ./CardBrick.sh --smoke-test       # non-interactive deployment check
+#   ./CardBrick.sh --input-diagnostic # controller test & calibration
+#   ./CardBrick.sh <any main.py args> # passthrough
+#
+# The app/runtime tree is treated as read-only; ALL mutable state goes
+# to $CARD_BRICK_DATA_DIR (default /userdata/saves/cardbrick).
+
+set -u  # undefined vars are bugs; no set -e — we want to log failures
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+GAMEDIR="${SCRIPT_DIR}/CardBrick"
+APP_DIR="${GAMEDIR}/cardbrick-py"
+
+# ------------------------------------------------------------- data dir
+CARD_BRICK_DATA_DIR="${CARD_BRICK_DATA_DIR:-/userdata/saves/cardbrick}"
+export CARD_BRICK_DATA_DIR
+LOG_DIR="${CARD_BRICK_DATA_DIR}/logs"
+LAUNCH_LOG="${LOG_DIR}/launch.log"
+mkdir -p "$LOG_DIR" || {
+    echo "FATAL: cannot create ${LOG_DIR} — is /userdata writable?" >&2
+    exit 1
+}
+
+log() { echo "$*" >> "$LAUNCH_LOG"; }
+fail() {
+    log "FATAL: $*"
+    echo "FATAL: $*" >&2
+    exit 1
+}
+
+log "=== CardBrick launch $(date) ==="
+
+[ -d "$APP_DIR" ] || fail "app directory not found: $APP_DIR"
+
+# -------------------------------------------------------------- runtime
+# Newest squashfs wins, so a runtime upgrade is just one file copy.
+RUNTIME_SQUASHFS="$(ls -1t "${GAMEDIR}/runtime/"pygame-ce_*.squashfs 2>/dev/null | head -n 1)"
+RUNTIME_EXTRACTED="${GAMEDIR}/runtime/extracted"   # unsquashed fallback
+MOUNTPOINT="${CARDBRICK_RUNTIME_MOUNT:-/tmp/cardbrick-runtime}"
+
+MOUNTED=""   # how we mounted, for cleanup: "", "loop" or "fuse"
+RUNTIME_DIR=""
+
+cleanup() {
+    cd /
+    case "$MOUNTED" in
+        loop) umount "$MOUNTPOINT" 2>/dev/null ;;
+        fuse) fusermount -u "$MOUNTPOINT" 2>/dev/null \
+                  || umount "$MOUNTPOINT" 2>/dev/null ;;
+    esac
+}
+trap cleanup EXIT INT TERM
+
+if [ -n "$RUNTIME_SQUASHFS" ]; then
+    mkdir -p "$MOUNTPOINT"
+    # A stale mount from a crashed run would shadow the new runtime.
+    umount "$MOUNTPOINT" 2>/dev/null
+    if mount -o loop,ro "$RUNTIME_SQUASHFS" "$MOUNTPOINT" 2>>"$LAUNCH_LOG"; then
+        MOUNTED="loop"
+        RUNTIME_DIR="$MOUNTPOINT"
+    elif command -v squashfuse >/dev/null 2>&1 \
+            && squashfuse "$RUNTIME_SQUASHFS" "$MOUNTPOINT" 2>>"$LAUNCH_LOG"; then
+        MOUNTED="fuse"
+        RUNTIME_DIR="$MOUNTPOINT"
+    else
+        log "WARN: could not mount $RUNTIME_SQUASHFS"
+    fi
+fi
+
+if [ -z "$RUNTIME_DIR" ] && [ -x "${RUNTIME_EXTRACTED}/bin/python3" ]; then
+    log "using extracted runtime fallback: $RUNTIME_EXTRACTED"
+    RUNTIME_DIR="$RUNTIME_EXTRACTED"
+fi
+
+if [ -n "$RUNTIME_DIR" ]; then
+    PYTHON="${RUNTIME_DIR}/bin/python3"
+    [ -x "$PYTHON" ] || fail "runtime mounted but ${PYTHON} is missing/not executable"
+    # stdlib dir, e.g. .../lib/python3.12 (version-agnostic glob)
+    PY_LIB="$(ls -d "${RUNTIME_DIR}/lib/"python3.* 2>/dev/null | head -n 1)"
+    [ -n "$PY_LIB" ] || fail "no lib/python3.* inside runtime ${RUNTIME_DIR}"
+    export PYTHONHOME="$RUNTIME_DIR"
+    export PYTHONPATH="${PY_LIB}:${PY_LIB}/site-packages"
+    # libpython3.X.so.1.0 lives in runtime/lib (venv python is a copy of
+    # a --enable-shared build)
+    export LD_LIBRARY_PATH="${RUNTIME_DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+else
+    # Last resort: firmware python3 (needs pygame available system-wide).
+    log "WARN: no usable bundled runtime; falling back to system python3"
+    PYTHON="python3"
+    command -v python3 >/dev/null 2>&1 || fail "no bundled runtime and no system python3"
+fi
+
+# The squashfs (and possibly the whole SD card) is read-only — keep
+# .pyc files out of the app tree.
+export PYTHONPYCACHEPREFIX="${CARD_BRICK_DATA_DIR}/.pycache"
+
+# ------------------------------------------------------------------ SDL
+# `mali` is what the upstream runtime validated on Knulli / Allwinner
+# H700 (RG35XX family). If the screen stays black try kmsdrm:
+#   SDL_VIDEODRIVER=kmsdrm ./CardBrick.sh
+export SDL_VIDEODRIVER="${SDL_VIDEODRIVER:-mali}"
+export SDL_AUDIODRIVER="${SDL_AUDIODRIVER:-alsa}"
+
+# ---------------------------------------------------------------- launch
+{
+    echo "GAMEDIR=${GAMEDIR}"
+    echo "RUNTIME_SQUASHFS=${RUNTIME_SQUASHFS:-<none>}"
+    echo "RUNTIME_DIR=${RUNTIME_DIR:-<system python>}"
+    echo "PYTHON=${PYTHON}"
+    echo "PYTHONHOME=${PYTHONHOME:-<unset>}"
+    echo "PYTHONPATH=${PYTHONPATH:-<unset>}"
+    echo "SDL_VIDEODRIVER=${SDL_VIDEODRIVER}"
+    echo "SDL_AUDIODRIVER=${SDL_AUDIODRIVER}"
+    echo "CARD_BRICK_DATA_DIR=${CARD_BRICK_DATA_DIR}"
+    "$PYTHON" --version 2>&1
+} >> "$LAUNCH_LOG"
+
+cd "$APP_DIR" || fail "cannot cd to ${APP_DIR}"
+
+# First boot on this device: run the smoke test once and keep its output.
+if [ ! -f "${CARD_BRICK_DATA_DIR}/.smoke-ok" ] && [ "$#" -eq 0 ]; then
+    if "$PYTHON" main.py --knulli --smoke-test >> "$LAUNCH_LOG" 2>&1; then
+        touch "${CARD_BRICK_DATA_DIR}/.smoke-ok"
+        log "first-run smoke test PASSED"
+    else
+        log "first-run smoke test FAILED — see above; starting anyway"
+    fi
+fi
+
+if [ "$#" -gt 0 ]; then
+    # Passthrough mode (e.g. --smoke-test over SSH). Show output on the
+    # terminal AND keep it in the log.
+    "$PYTHON" main.py --knulli "$@" 2>&1 | tee -a "$LAUNCH_LOG"
+    exit_code=${PIPESTATUS[0]}
+    exit "$exit_code"
+fi
+
+"$PYTHON" main.py --knulli study --fullscreen >> "$LAUNCH_LOG" 2>&1

--- a/deploy/knulli/Makefile
+++ b/deploy/knulli/Makefile
@@ -1,0 +1,49 @@
+# CardBrick — Knulli / RG35XX SP packaging (pygame-ce squashfs runtime).
+# Run from deploy/knulli/. See PACKAGING.md for the full walkthrough.
+#
+#   make runtime          build the ARM64 squashfs runtime (Docker, slow, once)
+#   make package          stage dist/ + zip (needs the runtime, or
+#                         RUNTIME_SQUASHFS=/path/to/file.squashfs)
+#   make package-fast     app-only package, no runtime (quick iteration)
+#   make validate         check the staged package before deploying
+#   make deploy-sd        copy to a mounted SD card   [SD=/media/me/SHARE]
+#   make deploy-ssh       push over SSH               [HOST=root@192.168.1.42]
+#   make smoke-ssh        deploy over SSH + run the on-device smoke test
+#   make clean            remove dist/ (keeps the built runtime)
+#   make distclean        remove dist/ AND the built runtime
+
+SD    ?=
+HOST  ?=
+
+HOSTFLAG = $(if $(HOST),--host $(HOST),)
+
+.PHONY: runtime package package-fast validate deploy-sd deploy-ssh smoke-ssh clean distclean
+
+runtime:
+	scripts/build_runtime.sh
+
+package:
+	scripts/build_package.sh
+	scripts/validate_package.sh
+
+package-fast:
+	scripts/build_package.sh --no-runtime
+	scripts/validate_package.sh
+
+validate:
+	scripts/validate_package.sh
+
+deploy-sd:
+	scripts/deploy_sdcard.sh $(SD)
+
+deploy-ssh:
+	scripts/deploy_ssh.sh $(HOSTFLAG)
+
+smoke-ssh:
+	scripts/deploy_ssh.sh $(HOSTFLAG) --smoke
+
+clean:
+	rm -rf dist
+
+distclean: clean
+	rm -rf runtime-build/build

--- a/deploy/knulli/PACKAGING.md
+++ b/deploy/knulli/PACKAGING.md
@@ -1,0 +1,181 @@
+# Packaging CardBrick for Knulli / RG35XX SP (pygame-ce runtime)
+
+This is the supported way to put CardBrick on a Knulli handheld: the
+app ships unchanged, next to a self-contained ARM64 Python runtime
+built with the approach from
+[viniciusfs/pygame-ce-runtime](https://github.com/viniciusfs/pygame-ce-runtime)
+— a portable Python 3.12 virtual environment with pygame-ce, packed
+into a single SquashFS image that the launch script loop-mounts at
+start and unmounts at exit. The device needs **no preinstalled Python,
+no pip, no network**.
+
+Why a source-built runtime instead of pip wheels: the manylinux
+pygame-ce wheel bundles its own SDL2, which knows nothing about the
+handheld's display. The runtime builder compiles pygame-ce against
+SDL2 *headers* so it links `libSDL2-2.0.so.0` dynamically — on the
+device that resolves to Knulli's firmware SDL2, which has the
+`mali`/`kmsdrm` video drivers the RG35XX family actually needs. The
+Python 3.12.8 + pygame-ce 2.5.6 pair is what upstream validated on an
+RG35XX-H running Knulli (same Allwinner H700 family as the RG35XX SP).
+
+Everything below runs from `deploy/knulli/` on a PC.
+
+```
+deploy/knulli/
+├── Makefile                  # make runtime / package / validate / deploy-*
+├── CardBrick.sh              # on-device launch script (goes to roms/ports/)
+├── runtime-build/            # Docker ARM64 runtime builder
+│   ├── build-config          # PYTHON_VERSION / PYGAME_VERSION pins
+│   ├── docker-compose.yml
+│   ├── build-runtime.sh      # runs inside the container
+│   └── requirements.txt      # extra deps baked into the runtime (fsrs, …)
+├── scripts/
+│   ├── build_runtime.sh      # host wrapper for the Docker build
+│   ├── build_package.sh      # stage dist/ + zip
+│   ├── validate_package.sh   # pre-deploy checks ([PASS]/[WARN]/[FAIL])
+│   ├── deploy_sdcard.sh      # copy to a mounted SD card
+│   └── deploy_ssh.sh         # push over SSH (+ on-device smoke test)
+└── dist/                     # build output (gitignored)
+```
+
+## 0. Prerequisites (PC)
+
+- **Docker + docker compose** — only for building the runtime image.
+  On an x86 PC, ARM64 emulation must be enabled once:
+
+  ```sh
+  docker run --privileged --rm tonistiigi/binfmt --install arm64
+  ```
+
+- `zip` (for the SD-card archive), `python3` (validation),
+  optionally `squashfs-tools` (deeper validation) and `rsync`
+  (faster SD copies). None of these are needed on the device.
+
+No Docker? You can point the packager at any compatible prebuilt
+runtime file instead:
+`RUNTIME_SQUASHFS=/path/to/pygame-ce_2.5.6_python_3.12.8.squashfs make package`.
+
+## 1. Build the runtime (once, and after version bumps)
+
+```sh
+cd deploy/knulli
+make runtime
+```
+
+This starts a Debian ARM64 container, compiles pygame-ce 2.5.6 from
+source, installs CardBrick's runtime deps (`runtime-build/requirements.txt`),
+and packs the venv into
+`runtime-build/build/pygame-ce_2.5.6_python_3.12.8.squashfs` (plus a
+`runtime-manifest.txt` recording exactly what went in). Under
+emulation on an x86 host this takes a while — it is a one-time cost;
+the artifact is reused by every subsequent package build.
+
+Version pins live in `runtime-build/build-config`. Optional
+`runtime-build/pre-install.sh` / `post-install.sh` hooks run inside
+the container before/after the venv is assembled.
+
+## 2. Build + validate the package
+
+```sh
+make package        # = build_package.sh + validate_package.sh
+```
+
+Produces:
+
+- `dist/CardBrick.sh` and `dist/CardBrick/` — exactly what lands in
+  `/userdata/roms/ports/` on the device (app code minus tests/caches,
+  the runtime squashfs, `VERSION`, `BUILD_INFO`, and a
+  `PACKAGE_MANIFEST.sha256` covering every file);
+- `dist/CardBrick-knulli-v<version>.zip` — the same tree zipped, for
+  manual SD-card installs.
+
+`make validate` re-runs the checks alone: launch-script syntax,
+required files, no stray caches, host-side `py_compile` of every
+source, squashfs integrity and contents (python3/libpython/pygame/fsrs
+present), checksum manifest, zip integrity.
+
+During development, `make package-fast` builds an app-only package
+(no runtime inside) — pair it with `deploy_ssh.sh`, which never
+re-uploads a runtime the device already has.
+
+## 3a. Deploy by SD card
+
+Either unzip `dist/CardBrick-knulli-v*.zip` into the card's
+`roms/ports/` yourself, or let the script find the card:
+
+```sh
+make deploy-sd                    # auto-detect mounted SHARE partition
+make deploy-sd SD=/media/$USER/SHARE
+scripts/deploy_sdcard.sh /Volumes/SHARE --clean   # wipe old app dir first
+```
+
+The script locates `roms/ports/` (SHARE root or bare roms partition),
+copies `CardBrick.sh` + `CardBrick/`, and runs `sync` before telling
+you it is safe to eject. On the device: if the Ports menu doesn't show
+CardBrick, Start menu → Games Settings → **Update Gamelists** (or
+reboot).
+
+## 3b. Deploy over SSH
+
+Knulli's SSH defaults: user `root`, password `linux`. Find the IP in
+the device's main menu (Network). For scripted deploys install a key
+once: `ssh-copy-id root@<ip>`.
+
+```sh
+make deploy-ssh HOST=root@192.168.1.42
+make smoke-ssh  HOST=root@192.168.1.42   # deploy + on-device smoke test
+scripts/deploy_ssh.sh --host root@192.168.1.42 --no-runtime  # code only
+```
+
+The script uploads with tar-over-ssh (no rsync needed on the device),
+skips the runtime upload when the on-device checksum already matches,
+verifies `PACKAGE_MANIFEST.sha256` on the device, pokes
+EmulationStation to reload the games list, and with `--smoke` runs
+the app's own `--smoke-test` on real hardware — one `[PASS]/[FAIL]`
+line per subsystem (display, font, DB, scheduler, controller, audio).
+
+## 4. On the device
+
+```
+/userdata/roms/ports/CardBrick.sh        # Ports-menu entry
+/userdata/roms/ports/CardBrick/
+├── cardbrick-py/                        # the app, read-only
+├── runtime/pygame-ce_*.squashfs         # mounted at /tmp/cardbrick-runtime
+├── VERSION  BUILD_INFO  PACKAGE_MANIFEST.sha256
+
+/userdata/saves/cardbrick/               # ALL mutable data (auto-created)
+├── cardbrick.db  settings.json  input_mapping.json  media/
+└── logs/launch.log + cardbrick.log      # start here when debugging
+```
+
+The launch script mounts the newest `runtime/*.squashfs`, exports
+`PYTHONHOME`/`PYTHONPATH`/`LD_LIBRARY_PATH` into it, keeps `.pyc`
+files in the data dir (`PYTHONPYCACHEPREFIX` — the app tree stays
+read-only), runs a one-time smoke test on first boot, and unmounts on
+exit. Run it manually over SSH for diagnostics:
+
+```sh
+bash /userdata/roms/ports/CardBrick.sh --smoke-test
+bash /userdata/roms/ports/CardBrick.sh --input-diagnostic
+```
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Black screen, app in log | Video driver. Default is `mali` (upstream-validated on Knulli/H700). Try `SDL_VIDEODRIVER=kmsdrm bash CardBrick.sh`; the winner can be exported permanently by editing `CardBrick.sh`. |
+| `could not mount … squashfs` in launch.log | Rare on Knulli (ports run as root). Fallbacks: install nothing — just unsquash on the PC and ship `CardBrick/runtime/extracted/` instead. |
+| `ImportError`/ABI errors at pygame init | Runtime/firmware mismatch — rebuild the runtime; don't mix wheels into it. The smoke test catches this at the `pygame init` step. |
+| Smoke test WARN on joystick/audio over SSH | Normal when ES owns the controller or audio is busy; verify from the Ports menu launch. |
+| Ports menu doesn't list CardBrick | Update Gamelists (Start → Games Settings) or reboot. |
+| Wrong/laggy buttons | Parent Mode → Controller test & setup; hold any button ~3 s to force calibration. |
+
+## Relationship to the older vendored-wheels docs
+
+`README.md` / `package_layout.md` / `launch_cardbrick_spanish.sh` in
+this folder describe the earlier, runtime-less option (firmware
+python3 + `pip install --target vendor`). It still works as a
+fallback when Docker is unavailable, but the squashfs runtime above is
+the recommended path — it pins the interpreter, survives firmware
+Python changes, and matches a combination already proven on this
+hardware family. `smoke_test_checklist.md` applies to both.

--- a/deploy/knulli/README.md
+++ b/deploy/knulli/README.md
@@ -1,5 +1,12 @@
 # CardBrick Spanish — Knulli / RG35XX SP Deployment
 
+> **Start with [`PACKAGING.md`](PACKAGING.md).** It documents the
+> recommended pipeline — a self-contained pygame-ce SquashFS runtime
+> (built the [viniciusfs/pygame-ce-runtime](https://github.com/viniciusfs/pygame-ce-runtime)
+> way) plus `make package` / `make deploy-sd` / `make deploy-ssh`
+> automation. This file describes the underlying app behaviour on the
+> device and the older vendored-wheels fallback.
+
 How to put the CardBrick-style Spanish study appliance on a Knulli
 (Batocera-derived) handheld. Read `package_layout.md` for the exact
 file tree and `smoke_test_checklist.md` for the pre-flight list.

--- a/deploy/knulli/runtime-build/build-config
+++ b/deploy/knulli/runtime-build/build-config
@@ -1,0 +1,8 @@
+# Versions for the pygame-ce squashfs runtime.
+#
+# This exact pair (Python 3.12.8 + pygame-ce 2.5.6) is the combination
+# validated by the upstream pygame-ce-runtime project on an Anbernic
+# RG35XX-H running Knulli — the same Allwinner H700 family as the
+# RG35XX SP. Bump them together and re-run the smoke test on hardware.
+PYTHON_VERSION=3.12.8
+PYGAME_VERSION=2.5.6

--- a/deploy/knulli/runtime-build/build-runtime.sh
+++ b/deploy/knulli/runtime-build/build-runtime.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Builds the pygame-ce squashfs runtime for CardBrick INSIDE the ARM64
+# builder container (see docker-compose.yml). Do not run on the host.
+#
+# Derived from https://github.com/viniciusfs/pygame-ce-runtime
+# (build-runtime.sh), adapted for CardBrick:
+#   - installs the app's extra deps (/local/requirements.txt) into the
+#     runtime so the device needs nothing but this one squashfs;
+#   - writes build/runtime-manifest.txt (pip freeze + versions) so a
+#     package can be traced back to exactly what is inside it.
+#
+# pygame-ce is deliberately built FROM SOURCE against Debian's SDL2
+# development headers instead of installing the manylinux wheel: the
+# wheel statically bundles its own SDL2, while a source build links
+# libSDL2-2.0.so.0 dynamically — on the device that resolves to
+# Knulli's firmware SDL2, which carries the mali/kmsdrm video drivers
+# the handheld display actually needs.
+
+set -euo pipefail
+
+: "${PYTHON_VERSION:?PYTHON_VERSION is required}"
+: "${PYGAME_VERSION:?PYGAME_VERSION is required}"
+
+export PY_VER=${PYTHON_VERSION%.*}
+
+cd "$HOME"
+
+# install dependencies
+apt update && apt install -y build-essential git rsync squashfs-tools \
+  libfreetype6-dev libportmidi-dev python3-dev python3-numpy \
+  libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev
+
+# optional pre-install hook
+if [[ -f /local/pre-install.sh ]]; then
+  bash /local/pre-install.sh
+fi
+
+# create runtime venv (--copies: no symlinks into the container image)
+python -m venv --copies /runtime
+source /runtime/bin/activate
+git clone --depth 1 --branch "${PYGAME_VERSION}" \
+  https://github.com/pygame-community/pygame-ce.git
+cd pygame-ce && python -m pip install .
+cd "$HOME"
+
+# CardBrick's own runtime dependencies
+if [[ -f /local/requirements.txt ]]; then
+  python -m pip install -r /local/requirements.txt
+fi
+
+# record what went in
+mkdir -p /local/build
+{
+  echo "python ${PYTHON_VERSION}"
+  echo "pygame-ce ${PYGAME_VERSION} (built from source against Debian SDL2)"
+  echo "built $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "---- pip freeze ----"
+  python -m pip freeze
+} > /local/build/runtime-manifest.txt
+
+deactivate
+
+# make the venv self-contained: interpreter shared lib + full stdlib
+cp "/usr/local/lib/libpython${PY_VER}.so.1.0" /runtime/lib/
+rsync -a "/usr/local/lib/python${PY_VER}/" "/runtime/lib/python${PY_VER}/"
+find /runtime -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+
+# optional post-install hook (runs right before squashing)
+if [[ -f /local/post-install.sh ]]; then
+  bash /local/post-install.sh
+fi
+
+# pack it
+ARTIFACT="pygame-ce_${PYGAME_VERSION}_python_${PYTHON_VERSION}.squashfs"
+mksquashfs /runtime "/${ARTIFACT}" -comp xz -b 1M
+mv "/${ARTIFACT}" "/local/build/${ARTIFACT}"
+
+echo "OK: /local/build/${ARTIFACT}"

--- a/deploy/knulli/runtime-build/docker-compose.yml
+++ b/deploy/knulli/runtime-build/docker-compose.yml
@@ -1,0 +1,22 @@
+# ARM64 builder for the CardBrick pygame-ce squashfs runtime.
+# Derived from https://github.com/viniciusfs/pygame-ce-runtime
+#
+# Run via ../scripts/build_runtime.sh (or `docker compose up` in this
+# directory). On an x86 host you need binfmt/qemu for linux/arm64 —
+# the wrapper script checks and tells you how to enable it.
+services:
+  runtime_builder:
+    image: python:3.12.8-bookworm
+    platform: linux/arm64
+    command:
+      - "/bin/bash"
+      - "-lc"
+      - "/local/build-runtime.sh 2>&1"
+    env_file:
+      - build-config
+    stdin_open: true
+    tty: true
+    volumes:
+      - type: bind
+        source: .
+        target: /local

--- a/deploy/knulli/runtime-build/requirements.txt
+++ b/deploy/knulli/runtime-build/requirements.txt
@@ -1,0 +1,8 @@
+# Extra Python dependencies baked INTO the squashfs runtime, on top of
+# pygame-ce (which build-runtime.sh compiles from source so that it
+# links the device's own SDL2 — that is what makes the `mali` video
+# driver work on Knulli).
+#
+# Keep this in sync with cardbrick-py/requirements.txt, minus pygame-ce.
+fsrs>=6.0
+typing-extensions>=4.0

--- a/deploy/knulli/scripts/build_package.sh
+++ b/deploy/knulli/scripts/build_package.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Assemble the deployable CardBrick package for Knulli / RG35XX SP.
+#
+#   deploy/knulli/dist/
+#   ├── CardBrick.sh                 # goes to /userdata/roms/ports/
+#   ├── CardBrick/                   # goes to /userdata/roms/ports/
+#   │   ├── cardbrick-py/            # the app, verbatim (no tests/caches)
+#   │   ├── runtime/pygame-ce_*.squashfs
+#   │   ├── VERSION  BUILD_INFO  PACKAGE_MANIFEST.sha256
+#   └── CardBrick-knulli-v<ver>.zip  # same content, zipped for SD card
+#
+# Usage:
+#   scripts/build_package.sh                 # runtime from runtime-build/build/
+#   RUNTIME_SQUASHFS=/path/x.squashfs scripts/build_package.sh
+#   scripts/build_package.sh --no-runtime    # app-only (fast re-deploys of
+#                                            # code onto a device that
+#                                            # already has the runtime)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KNULLI_DIR="$(cd "${HERE}/.." && pwd)"
+REPO_ROOT="$(cd "${KNULLI_DIR}/../.." && pwd)"
+APP_SRC="${REPO_ROOT}/cardbrick-py"
+DIST="${KNULLI_DIR}/dist"
+STAGE="${DIST}/CardBrick"
+
+WITH_RUNTIME=1
+for arg in "$@"; do
+    case "$arg" in
+        --no-runtime) WITH_RUNTIME=0 ;;
+        *) echo "unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+[ -f "${APP_SRC}/main.py" ] || { echo "ERROR: ${APP_SRC}/main.py missing" >&2; exit 1; }
+
+VERSION="$(sed -n 's/^__version__ *= *"\([^"]*\)".*/\1/p' \
+    "${APP_SRC}/cardbrick/__init__.py" | head -n 1)"
+VERSION="${VERSION:-0.0.0}"
+
+# ----------------------------------------------------------- find runtime
+RUNTIME_FILE=""
+if [ "$WITH_RUNTIME" -eq 1 ]; then
+    if [ -n "${RUNTIME_SQUASHFS:-}" ]; then
+        RUNTIME_FILE="$RUNTIME_SQUASHFS"
+    else
+        RUNTIME_FILE="$(ls -1t "${KNULLI_DIR}/runtime-build/build/"pygame-ce_*.squashfs 2>/dev/null | head -n 1 || true)"
+    fi
+    if [ -z "$RUNTIME_FILE" ] || [ ! -s "$RUNTIME_FILE" ]; then
+        echo "ERROR: no runtime squashfs found." >&2
+        echo "Build one first:   scripts/build_runtime.sh" >&2
+        echo "or point at one:   RUNTIME_SQUASHFS=/path/to/pygame-ce_*.squashfs $0" >&2
+        echo "or skip it:        $0 --no-runtime" >&2
+        exit 1
+    fi
+fi
+
+# ------------------------------------------------------------------ stage
+echo "Staging CardBrick v${VERSION} -> ${STAGE}"
+rm -rf "$STAGE" "${DIST}/CardBrick.sh"
+mkdir -p "$STAGE"
+
+# Copy the app verbatim, minus things the device never needs. tar keeps
+# this portable (no rsync requirement on the host).
+( cd "${REPO_ROOT}" && tar cf - \
+      --exclude='cardbrick-py/tests' \
+      --exclude='cardbrick-py/data' \
+      --exclude='__pycache__' \
+      --exclude='.pytest_cache' \
+      --exclude='*.pyc' \
+      --exclude='.DS_Store' \
+      cardbrick-py ) | ( cd "$STAGE" && tar xf - )
+
+install -m 755 "${KNULLI_DIR}/CardBrick.sh" "${DIST}/CardBrick.sh"
+
+if [ -n "$RUNTIME_FILE" ]; then
+    mkdir -p "${STAGE}/runtime"
+    cp "$RUNTIME_FILE" "${STAGE}/runtime/"
+    RUNTIME_MANIFEST="$(dirname "$RUNTIME_FILE")/runtime-manifest.txt"
+    [ -f "$RUNTIME_MANIFEST" ] && cp "$RUNTIME_MANIFEST" "${STAGE}/runtime/"
+fi
+
+echo "$VERSION" > "${STAGE}/VERSION"
+{
+    echo "version=${VERSION}"
+    echo "built=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "git=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    echo "runtime=$( [ -n "$RUNTIME_FILE" ] && basename "$RUNTIME_FILE" || echo none )"
+} > "${STAGE}/BUILD_INFO"
+
+# Checksums over everything in the bundle (verified by validate_package.sh
+# and re-verifiable on-device over SSH).
+( cd "$STAGE" && find . -type f ! -name PACKAGE_MANIFEST.sha256 -print0 \
+      | sort -z | xargs -0 sha256sum ) > "${STAGE}/PACKAGE_MANIFEST.sha256"
+
+# -------------------------------------------------------------------- zip
+SUFFIX=""
+[ "$WITH_RUNTIME" -eq 0 ] && SUFFIX="-noruntime"
+ZIP_NAME="CardBrick-knulli-v${VERSION}${SUFFIX}.zip"
+if command -v zip >/dev/null 2>&1; then
+    ( cd "$DIST" && rm -f "$ZIP_NAME" && zip -qr "$ZIP_NAME" CardBrick.sh CardBrick )
+    echo "Zip:   ${DIST}/${ZIP_NAME}"
+else
+    echo "WARN: 'zip' not found — skipped zip archive (dist/ tree is complete)"
+fi
+
+echo "Stage: ${STAGE}"
+echo "Next:  scripts/validate_package.sh"

--- a/deploy/knulli/scripts/build_package.sh
+++ b/deploy/knulli/scripts/build_package.sh
@@ -60,16 +60,17 @@ echo "Staging CardBrick v${VERSION} -> ${STAGE}"
 rm -rf "$STAGE" "${DIST}/CardBrick.sh"
 mkdir -p "$STAGE"
 
-# Copy the app verbatim, minus things the device never needs. tar keeps
-# this portable (no rsync requirement on the host).
-( cd "${REPO_ROOT}" && tar cf - \
-      --exclude='cardbrick-py/tests' \
-      --exclude='cardbrick-py/data' \
-      --exclude='__pycache__' \
-      --exclude='.pytest_cache' \
-      --exclude='*.pyc' \
-      --exclude='.DS_Store' \
-      cardbrick-py ) | ( cd "$STAGE" && tar xf - )
+# Copy the app verbatim, then strip what the device never needs. Filter
+# AFTER copying rather than via `tar --exclude`: GNU tar and macOS's
+# bsdtar disagree on whether an unslashed exclude pattern prunes nested
+# directories, so relying on it silently ships __pycache__/tests on some
+# hosts. find+rm behaves identically everywhere.
+( cd "${REPO_ROOT}" && tar cf - cardbrick-py ) | ( cd "$STAGE" && tar xf - )
+rm -rf "${STAGE}/cardbrick-py/tests" "${STAGE}/cardbrick-py/data"
+find "${STAGE}/cardbrick-py" \
+    \( -type d -name '__pycache__' -o -type d -name '.pytest_cache' \) \
+    -exec rm -rf {} +
+find "${STAGE}/cardbrick-py" -type f \( -name '*.pyc' -o -name '.DS_Store' \) -delete
 
 install -m 755 "${KNULLI_DIR}/CardBrick.sh" "${DIST}/CardBrick.sh"
 

--- a/deploy/knulli/scripts/build_package.sh
+++ b/deploy/knulli/scripts/build_package.sh
@@ -60,13 +60,23 @@ echo "Staging CardBrick v${VERSION} -> ${STAGE}"
 rm -rf "$STAGE" "${DIST}/CardBrick.sh"
 mkdir -p "$STAGE"
 
-# Copy the app verbatim, then strip what the device never needs. Filter
-# AFTER copying rather than via `tar --exclude`: GNU tar and macOS's
-# bsdtar disagree on whether an unslashed exclude pattern prunes nested
-# directories, so relying on it silently ships __pycache__/tests on some
-# hosts. find+rm behaves identically everywhere.
-( cd "${REPO_ROOT}" && tar cf - cardbrick-py ) | ( cd "$STAGE" && tar xf - )
-rm -rf "${STAGE}/cardbrick-py/tests" "${STAGE}/cardbrick-py/data"
+# Copy an ALLOWLIST of what actually ships (matches the tree documented
+# in package_layout.md), rather than the whole cardbrick-py/ directory
+# minus excludes. A denylist misses local dev cruft that doesn't have a
+# fixed name or location — most commonly a virtualenv created inside
+# cardbrick-py/ (.venv, venv, env), whose installed packages routinely
+# bundle their own nested tests/ and __pycache__ dirs. Copying only the
+# known app paths makes that class of leak structurally impossible.
+mkdir -p "${STAGE}/cardbrick-py"
+cp "${APP_SRC}/main.py" "${STAGE}/cardbrick-py/"
+[ -f "${APP_SRC}/requirements.txt" ] && cp "${APP_SRC}/requirements.txt" "${STAGE}/cardbrick-py/"
+[ -f "${APP_SRC}/README.md" ] && cp "${APP_SRC}/README.md" "${STAGE}/cardbrick-py/"
+for d in cardbrick assets scripts; do
+    [ -d "${APP_SRC}/${d}" ] || continue
+    ( cd "${APP_SRC}" && tar cf - "$d" ) | ( cd "${STAGE}/cardbrick-py" && tar xf - )
+done
+# Belt-and-suspenders: strip any cache dirs that did come from a tracked
+# path above (e.g. a stray __pycache__ committed by accident).
 find "${STAGE}/cardbrick-py" \
     \( -type d -name '__pycache__' -o -type d -name '.pytest_cache' \) \
     -exec rm -rf {} +

--- a/deploy/knulli/scripts/build_runtime.sh
+++ b/deploy/knulli/scripts/build_runtime.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the ARM64 pygame-ce squashfs runtime on a PC (host-side wrapper
+# around runtime-build/docker-compose.yml).
+#
+# Output: deploy/knulli/runtime-build/build/pygame-ce_<PG>_python_<PY>.squashfs
+#
+# Requirements on the host: docker + docker compose. On an x86 host the
+# linux/arm64 container needs binfmt/qemu emulation (see error hint).
+#
+# Already have a runtime squashfs (e.g. built earlier, or from the
+# upstream pygame-ce-runtime project)? Skip this script and pass it to
+# build_package.sh via RUNTIME_SQUASHFS=/path/to/file.squashfs.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${HERE}/../runtime-build"
+
+command -v docker >/dev/null 2>&1 || {
+    echo "ERROR: docker not found. Install Docker, or supply a prebuilt" >&2
+    echo "runtime via RUNTIME_SQUASHFS= when running build_package.sh." >&2
+    exit 1
+}
+
+# Fail early with a useful hint if arm64 emulation is missing.
+if [ "$(uname -m)" != "aarch64" ] && [ "$(uname -m)" != "arm64" ]; then
+    if ! docker run --rm --platform linux/arm64 python:3.12.8-bookworm true 2>/dev/null; then
+        echo "ERROR: this host cannot run linux/arm64 containers." >&2
+        echo "Enable qemu binfmt emulation and retry:" >&2
+        echo "    docker run --privileged --rm tonistiigi/binfmt --install arm64" >&2
+        exit 1
+    fi
+fi
+
+# shellcheck disable=SC1091
+. "${BUILD_DIR}/build-config"
+ARTIFACT="pygame-ce_${PYGAME_VERSION}_python_${PYTHON_VERSION}.squashfs"
+
+echo "Building ${ARTIFACT} (this compiles pygame-ce under emulation —"
+echo "expect it to take a while on an x86 host)..."
+( cd "$BUILD_DIR" && docker compose up --abort-on-container-exit )
+( cd "$BUILD_DIR" && docker compose down --remove-orphans ) || true
+
+OUT="${BUILD_DIR}/build/${ARTIFACT}"
+if [ ! -s "$OUT" ]; then
+    echo "ERROR: expected artifact not found: ${OUT}" >&2
+    echo "Check the container output above for the real failure." >&2
+    exit 1
+fi
+
+echo "OK: ${OUT} ($(du -h "$OUT" | cut -f1))"
+[ -f "${BUILD_DIR}/build/runtime-manifest.txt" ] \
+    && echo "Manifest: ${BUILD_DIR}/build/runtime-manifest.txt"

--- a/deploy/knulli/scripts/deploy_sdcard.sh
+++ b/deploy/knulli/scripts/deploy_sdcard.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Copy the built CardBrick package onto a Knulli SD card mounted on this
+# PC. Works with either the single-card layout (SHARE partition with
+# roms/ at its root) or a directly-mounted roms partition.
+#
+# Usage:
+#   scripts/deploy_sdcard.sh                # auto-detect mounted card
+#   scripts/deploy_sdcard.sh /media/me/SHARE
+#   scripts/deploy_sdcard.sh /Volumes/SHARE --clean
+#
+# --clean removes the existing CardBrick/ folder on the card first
+# (never touches anything else, and never touches /userdata/saves data
+# on the device — that lives on the card only as saves/, which this
+# script does not write to).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="$(cd "${HERE}/.." && pwd)/dist"
+STAGE="${DIST}/CardBrick"
+
+SD_ROOT=""
+CLEAN=0
+for arg in "$@"; do
+    case "$arg" in
+        --clean) CLEAN=1 ;;
+        -*) echo "unknown option: $arg" >&2; exit 2 ;;
+        *) SD_ROOT="$arg" ;;
+    esac
+done
+
+[ -d "$STAGE" ] && [ -f "${DIST}/CardBrick.sh" ] || {
+    echo "ERROR: nothing staged in ${DIST} — run scripts/build_package.sh first" >&2
+    exit 1
+}
+
+# ------------------------------------------------- locate the ports dir
+ports_dir_for() {
+    # Accept the SHARE root, a roms dir, or the ports dir itself.
+    for c in "$1/roms/ports" "$1/ports" "$1"; do
+        case "$c" in */ports) [ -d "$c" ] && { echo "$c"; return 0; } ;; esac
+    done
+    return 1
+}
+
+PORTS_DIR=""
+if [ -n "$SD_ROOT" ]; then
+    PORTS_DIR="$(ports_dir_for "$SD_ROOT")" || {
+        echo "ERROR: no roms/ports directory under ${SD_ROOT}." >&2
+        echo "Is this the Knulli SHARE partition? (It should contain roms/, bios/, saves/...)" >&2
+        exit 1
+    }
+else
+    echo "No SD path given — scanning common mount points..."
+    for base in /media/*/* /media/* /run/media/*/* /Volumes/*; do
+        [ -d "$base" ] || continue
+        if p="$(ports_dir_for "$base" 2>/dev/null)"; then
+            echo "  found: $p"
+            if [ -n "$PORTS_DIR" ]; then
+                echo "ERROR: multiple candidate cards found — pass the path explicitly." >&2
+                exit 1
+            fi
+            PORTS_DIR="$p"
+        fi
+    done
+    [ -n "$PORTS_DIR" ] || {
+        echo "ERROR: no mounted SD card with a roms/ports directory found." >&2
+        echo "Mount the Knulli SHARE partition and pass its path, e.g.:" >&2
+        echo "    $0 /media/\$USER/SHARE" >&2
+        exit 1
+    }
+fi
+
+echo "Deploying to: ${PORTS_DIR}"
+
+if [ "$CLEAN" -eq 1 ] && [ -d "${PORTS_DIR}/CardBrick" ]; then
+    echo "Removing existing ${PORTS_DIR}/CardBrick (--clean)"
+    rm -rf "${PORTS_DIR}/CardBrick"
+fi
+
+# rsync when available (delta copy — the ~xx MB runtime is skipped when
+# unchanged); plain cp otherwise.
+if command -v rsync >/dev/null 2>&1; then
+    rsync -rt --delete "${STAGE}/" "${PORTS_DIR}/CardBrick/"
+    rsync -t --chmod=ugo+x "${DIST}/CardBrick.sh" "${PORTS_DIR}/CardBrick.sh"
+else
+    mkdir -p "${PORTS_DIR}/CardBrick"
+    cp -R "${STAGE}/." "${PORTS_DIR}/CardBrick/"
+    cp "${DIST}/CardBrick.sh" "${PORTS_DIR}/CardBrick.sh"
+fi
+chmod +x "${PORTS_DIR}/CardBrick.sh" 2>/dev/null || true  # FAT has no exec bit; Knulli copes
+
+echo "Flushing writes to the card (sync)..."
+sync
+
+echo
+echo "Done. Now:"
+echo "  1. Eject the card safely, put it in the device, boot."
+echo "  2. If 'CardBrick' does not appear under Ports: Start menu ->"
+echo "     Games Settings -> Update Gamelists (or just reboot)."
+echo "  3. First launch runs a self-check; see"
+echo "     /userdata/saves/cardbrick/logs/launch.log if anything is off."

--- a/deploy/knulli/scripts/deploy_ssh.sh
+++ b/deploy/knulli/scripts/deploy_ssh.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Deploy the built CardBrick package to a Knulli device over SSH, with
+# an optional on-device smoke test afterwards.
+#
+# Usage:
+#   scripts/deploy_ssh.sh                        # root@knulli.local
+#   scripts/deploy_ssh.sh --host root@192.168.1.42
+#   scripts/deploy_ssh.sh --smoke                # + run smoke test after
+#   scripts/deploy_ssh.sh --no-runtime           # code only, keep the
+#                                                # runtime already on the
+#                                                # device (fast iteration)
+#
+# Env:
+#   CARDBRICK_DEVICE   default host (e.g. root@192.168.1.42)
+#
+# Knulli SSH defaults: user root, password 'linux'. For scripted use
+# install a key once:  ssh-copy-id root@knulli.local
+# (If sshpass is installed and SSHPASS is exported, it is used
+# automatically.)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="$(cd "${HERE}/.." && pwd)/dist"
+STAGE="${DIST}/CardBrick"
+REMOTE_PORTS="/userdata/roms/ports"
+
+HOST="${CARDBRICK_DEVICE:-root@knulli.local}"
+SMOKE=0
+PUSH_RUNTIME=1
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --host) HOST="$2"; shift ;;
+        --smoke) SMOKE=1 ;;
+        --no-runtime) PUSH_RUNTIME=0 ;;
+        *) echo "unknown option: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+[ -d "$STAGE" ] && [ -f "${DIST}/CardBrick.sh" ] || {
+    echo "ERROR: nothing staged in ${DIST} — run scripts/build_package.sh first" >&2
+    exit 1
+}
+
+SSH="ssh"
+if [ -n "${SSHPASS:-}" ] && command -v sshpass >/dev/null 2>&1; then
+    SSH="sshpass -e ssh"
+fi
+
+run_remote() { $SSH "$HOST" "$@"; }
+
+echo "Checking connection to ${HOST}..."
+run_remote "true" || {
+    echo "ERROR: cannot SSH to ${HOST}." >&2
+    echo "  - Is the device on and on the network? (Knulli main menu -> Network shows the IP)" >&2
+    echo "  - Try: scripts/deploy_ssh.sh --host root@<ip>   (password: linux)" >&2
+    exit 1
+}
+
+run_remote "mkdir -p '${REMOTE_PORTS}/CardBrick'"
+
+# --------------------------------------------------------- runtime file
+# The squashfs is the big, rarely-changing part — skip the transfer when
+# the device already has the identical file.
+RUNTIME_FILE="$(ls -1 "${STAGE}/runtime/"pygame-ce_*.squashfs 2>/dev/null | head -n 1 || true)"
+SKIP_RUNTIME_COPY=0
+if [ -n "$RUNTIME_FILE" ] && [ "$PUSH_RUNTIME" -eq 1 ]; then
+    NAME="$(basename "$RUNTIME_FILE")"
+    LOCAL_SUM="$(sha256sum "$RUNTIME_FILE" | cut -d' ' -f1)"
+    REMOTE_SUM="$(run_remote "sha256sum '${REMOTE_PORTS}/CardBrick/runtime/${NAME}' 2>/dev/null | cut -d' ' -f1" || true)"
+    if [ -n "$REMOTE_SUM" ] && [ "$REMOTE_SUM" = "$LOCAL_SUM" ]; then
+        echo "Runtime ${NAME} already on device (checksum match) — skipping upload."
+        SKIP_RUNTIME_COPY=1
+    fi
+fi
+
+# --------------------------------------------------------------- upload
+# tar-over-ssh: works against BusyBox, no rsync needed on the device,
+# preserves the executable bit regardless of FAT quirks.
+echo "Uploading app$( [ "$SKIP_RUNTIME_COPY" -eq 0 ] && [ -n "$RUNTIME_FILE" ] && [ "$PUSH_RUNTIME" -eq 1 ] && echo ' + runtime' ) to ${HOST}:${REMOTE_PORTS} ..."
+
+TAR_EXCLUDES=()
+if [ "$PUSH_RUNTIME" -eq 0 ] || [ "$SKIP_RUNTIME_COPY" -eq 1 ]; then
+    TAR_EXCLUDES+=(--exclude='CardBrick/runtime')
+fi
+
+( cd "$DIST" && tar cf - ${TAR_EXCLUDES[@]+"${TAR_EXCLUDES[@]}"} CardBrick.sh CardBrick ) \
+    | run_remote "cd '${REMOTE_PORTS}' && tar xf -"
+
+run_remote "chmod +x '${REMOTE_PORTS}/CardBrick.sh'"
+
+# ---------------------------------------------------------- verification
+echo "Verifying checksums on device..."
+if run_remote "cd '${REMOTE_PORTS}/CardBrick' && sha256sum -c PACKAGE_MANIFEST.sha256 >/dev/null 2>&1"; then
+    echo "  checksums OK"
+else
+    if [ "$PUSH_RUNTIME" -eq 0 ]; then
+        echo "  (manifest covers the runtime too — mismatches are expected with --no-runtime)"
+    else
+        echo "WARNING: on-device checksum verification failed — retry the deploy." >&2
+        exit 1
+    fi
+fi
+
+# Refresh the Ports list so the entry appears without a reboot
+# (EmulationStation HTTP API; harmless if unavailable).
+run_remote "curl -s -o /dev/null http://localhost:1234/reloadgames || true" 2>/dev/null || true
+
+if [ "$SMOKE" -eq 1 ]; then
+    echo
+    echo "Running on-device smoke test..."
+    if run_remote "bash '${REMOTE_PORTS}/CardBrick.sh' --smoke-test"; then
+        echo "SMOKE TEST: PASS"
+    else
+        echo "SMOKE TEST: FAIL — full log: ${HOST}:/userdata/saves/cardbrick/logs/launch.log" >&2
+        exit 1
+    fi
+fi
+
+echo
+echo "Deployed. Launch 'CardBrick' from the Ports menu."
+echo "(Not listed? Start menu -> Games Settings -> Update Gamelists.)"

--- a/deploy/knulli/scripts/validate_package.sh
+++ b/deploy/knulli/scripts/validate_package.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Validate the staged CardBrick package (deploy/knulli/dist/) BEFORE it
+# touches a device. Prints one [PASS]/[WARN]/[FAIL] line per check, in
+# the same spirit as the app's own --smoke-test; exits non-zero if any
+# hard check failed.
+#
+# Usage: scripts/validate_package.sh [path-to-dist]   (default: ../dist)
+
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST="${1:-$(cd "${HERE}/.." && pwd)/dist}"
+STAGE="${DIST}/CardBrick"
+
+FAILURES=0
+pass() { echo "[PASS] $*"; }
+warn() { echo "[WARN] $*"; }
+fail() { echo "[FAIL] $*"; FAILURES=$((FAILURES + 1)); }
+
+[ -d "$STAGE" ] || { fail "stage dir missing: ${STAGE} — run build_package.sh first"; exit 1; }
+
+# ------------------------------------------------------ launch script
+LAUNCHER="${DIST}/CardBrick.sh"
+if [ -f "$LAUNCHER" ]; then
+    if bash -n "$LAUNCHER" 2>/dev/null; then
+        pass "CardBrick.sh: bash syntax OK"
+    else
+        fail "CardBrick.sh: syntax error (bash -n)"
+    fi
+    if [ -x "$LAUNCHER" ]; then
+        pass "CardBrick.sh: executable bit set"
+    else
+        fail "CardBrick.sh: not executable (chmod +x needed)"
+    fi
+else
+    fail "CardBrick.sh missing from ${DIST}"
+fi
+
+# -------------------------------------------------------- app content
+for f in \
+    "cardbrick-py/main.py" \
+    "cardbrick-py/cardbrick/__init__.py" \
+    "cardbrick-py/cardbrick/app.py" \
+    "cardbrick-py/cardbrick/paths.py" \
+    "cardbrick-py/cardbrick/smoke.py" \
+    "cardbrick-py/assets/fonts/DejaVuSans.ttf" \
+    "VERSION" "BUILD_INFO" "PACKAGE_MANIFEST.sha256"
+do
+    if [ -e "${STAGE}/${f}" ]; then
+        pass "present: ${f}"
+    else
+        fail "missing: ${f}"
+    fi
+done
+
+if find "$STAGE" \( -name '__pycache__' -o -name '*.pyc' -o -path '*/tests/*' \) \
+        -print -quit 2>/dev/null | grep -q .; then
+    fail "bundle contains __pycache__/.pyc/tests files (should be excluded)"
+else
+    pass "no __pycache__/.pyc/tests in bundle"
+fi
+
+# All Python sources must at least compile with the host interpreter.
+if command -v python3 >/dev/null 2>&1; then
+    if ( cd "${STAGE}/cardbrick-py" && \
+         find . -name '*.py' -print0 | xargs -0 python3 -m py_compile 2>/tmp/pyc.err ); then
+        pass "python sources compile (host python3)"
+    else
+        fail "py_compile errors: $(head -n 3 /tmp/pyc.err 2>/dev/null | tr '\n' ' ')"
+    fi
+    # py_compile with default args writes __pycache__ next to sources — undo.
+    find "${STAGE}/cardbrick-py" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null
+else
+    warn "python3 not on host — skipped source compile check"
+fi
+
+# ------------------------------------------------------------ runtime
+RUNTIME_FILE="$(ls -1 "${STAGE}/runtime/"pygame-ce_*.squashfs 2>/dev/null | head -n 1)"
+if [ -n "$RUNTIME_FILE" ]; then
+    pass "runtime present: $(basename "$RUNTIME_FILE") ($(du -h "$RUNTIME_FILE" | cut -f1))"
+
+    # squashfs superblock magic: 'hsqs'
+    MAGIC="$(head -c 4 "$RUNTIME_FILE" 2>/dev/null)"
+    if [ "$MAGIC" = "hsqs" ]; then
+        pass "runtime: valid squashfs magic"
+    else
+        fail "runtime: not a squashfs image (bad magic)"
+    fi
+
+    if command -v unsquashfs >/dev/null 2>&1; then
+        if unsquashfs -s "$RUNTIME_FILE" >/dev/null 2>&1; then
+            pass "runtime: unsquashfs superblock check OK"
+        else
+            fail "runtime: unsquashfs cannot read the image"
+        fi
+        LISTING="$(unsquashfs -l "$RUNTIME_FILE" 2>/dev/null)"
+        for want in "/bin/python3" "/lib/libpython" "site-packages/pygame"; do
+            if echo "$LISTING" | grep -q "$want"; then
+                pass "runtime contains ${want}"
+            else
+                fail "runtime is missing ${want}"
+            fi
+        done
+        if echo "$LISTING" | grep -q "site-packages/fsrs"; then
+            pass "runtime contains fsrs"
+        else
+            fail "runtime is missing fsrs (was runtime-build/requirements.txt applied?)"
+        fi
+    else
+        warn "unsquashfs not on host — install squashfs-tools for deep runtime checks"
+    fi
+else
+    warn "no runtime squashfs in bundle (--no-runtime build?) — device must already have one"
+fi
+
+# ----------------------------------------------------------- checksums
+if command -v sha256sum >/dev/null 2>&1 && [ -f "${STAGE}/PACKAGE_MANIFEST.sha256" ]; then
+    if ( cd "$STAGE" && sha256sum --quiet -c PACKAGE_MANIFEST.sha256 2>/dev/null ); then
+        pass "PACKAGE_MANIFEST.sha256 verifies"
+    else
+        fail "checksum mismatch against PACKAGE_MANIFEST.sha256"
+    fi
+fi
+
+# ------------------------------------------------------------------ zip
+ZIP="$(ls -1t "${DIST}/"CardBrick-knulli-*.zip 2>/dev/null | head -n 1)"
+if [ -n "$ZIP" ]; then
+    if command -v unzip >/dev/null 2>&1; then
+        if unzip -tqq "$ZIP" >/dev/null 2>&1; then
+            pass "zip integrity OK: $(basename "$ZIP")"
+        else
+            fail "zip is corrupt: $(basename "$ZIP")"
+        fi
+    else
+        warn "unzip not on host — skipped zip integrity check"
+    fi
+fi
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+    echo "RESULT: PASS — package is ready to deploy (SD card or SSH)."
+else
+    echo "RESULT: FAIL — ${FAILURES} problem(s) above must be fixed first."
+    exit 1
+fi

--- a/deploy/knulli/scripts/validate_package.sh
+++ b/deploy/knulli/scripts/validate_package.sh
@@ -53,9 +53,11 @@ do
     fi
 done
 
-if find "$STAGE" \( -name '__pycache__' -o -name '*.pyc' -o -path '*/tests/*' \) \
-        -print -quit 2>/dev/null | grep -q .; then
-    fail "bundle contains __pycache__/.pyc/tests files (should be excluded)"
+STRAY="$(find "$STAGE" \( -name '__pycache__' -o -name '*.pyc' -o -path '*/tests/*' \) \
+        -print 2>/dev/null | head -n 5)"
+if [ -n "$STRAY" ]; then
+    fail "bundle contains __pycache__/.pyc/tests files (should be excluded):"
+    echo "$STRAY" | sed 's/^/       /'
 else
     pass "no __pycache__/.pyc/tests in bundle"
 fi


### PR DESCRIPTION
## Summary

This PR adds a complete, production-ready packaging pipeline for deploying CardBrick to Knulli handheld devices (RG35XX SP and compatible hardware). The solution uses a self-contained ARM64 Python 3.12 + pygame-ce 2.5.6 runtime packaged as a SquashFS image, eliminating device-side dependencies while ensuring pygame-ce links against the firmware's SDL2 (enabling proper `mali`/`kmsdrm` video driver support).

## Key Changes

- **PACKAGING.md**: Comprehensive guide covering the entire workflow—from building the runtime once via Docker to deploying via SD card or SSH, with troubleshooting and on-device architecture details.

- **CardBrick.sh**: On-device launch script that:
  - Loop-mounts the squashfs runtime at startup
  - Configures Python environment (`PYTHONHOME`, `PYTHONPATH`, `LD_LIBRARY_PATH`)
  - Runs a one-time smoke test on first boot
  - Supports passthrough arguments (`--smoke-test`, `--input-diagnostic`)
  - Falls back to system Python or extracted runtime if needed
  - Cleans up mounts on exit

- **Build pipeline** (`scripts/`):
  - `build_runtime.sh`: Host wrapper for Docker-based ARM64 runtime compilation
  - `build_package.sh`: Stages the app + runtime into `dist/`, generates checksums and BUILD_INFO
  - `validate_package.sh`: Pre-deployment checks (bash syntax, required files, no caches, py_compile, squashfs integrity, manifest verification)
  - `deploy_sdcard.sh`: Auto-detects mounted Knulli SD card and copies the package
  - `deploy_ssh.sh`: Uploads via tar-over-ssh with smart runtime skipping (checksums match), optional on-device smoke test

- **Runtime builder** (`runtime-build/`):
  - `docker-compose.yml`: ARM64 Debian container for compilation
  - `build-runtime.sh`: Compiles pygame-ce from source against SDL2 headers (not manylinux wheel), installs extra deps, packs venv into squashfs
  - `build-config`: Version pins (Python 3.12.8, pygame-ce 2.5.6—validated upstream on RG35XX-H)
  - `requirements.txt`: Extra Python packages baked into the runtime

- **Makefile**: Convenient targets for the full workflow (`make runtime`, `make package`, `make deploy-ssh`, etc.)

- **Updated README.md**: Points to PACKAGING.md as the primary reference; notes the older vendored-wheels approach as a fallback.

## Notable Implementation Details

- **Source-built pygame-ce**: Compiled against Debian SDL2 headers so it dynamically links `libSDL2-2.0.so.0`, which resolves to Knulli's firmware SDL2 with proper video drivers—unlike the manylinux wheel which bundles its own SDL2.
- **Read-only app tree**: `.pyc` files are redirected to the data directory via `PYTHONPYCACHEPREFIX` so the app and runtime remain immutable.
- **Smart deployment**: SSH deploy skips the ~100 MB runtime when checksums match; `--no-runtime` flag enables fast code-only iteration.
- **Comprehensive validation**: Pre-deploy checks catch syntax errors, missing files, stray caches, and squashfs corruption before touching a device.
- **Fallback chain**: Prefers squashfs mount → unsquashed extracted runtime → system Python, with clear logging at each step.

https://claude.ai/code/session_01TWGDLyDfezo58FxbCFzKih