### PR TITLE
Route to controller setup when joystick present without saved mapping

### DIFF
--- a/cardbrick-py/cardbrick/app.py
+++ b/cardbrick-py/cardbrick/app.py
@@ -182,8 +182,12 @@ class CardBrickApp:
         self._init_display()
         pygame.display.set_caption("CardBrick — Spanish Practice")
         pygame.mouse.set_visible(False)
+        # In pygame 2 the SDL device closes again when a Joystick object
+        # is garbage collected, and SDL only delivers button/hat events
+        # for open devices — these references are what keeps input alive.
+        self._joysticks = {}
         for i in range(pygame.joystick.get_count()):
-            pygame.joystick.Joystick(i).init()
+            self._open_joystick(i)
 
         self.font_big = _load_font(38)
         self.font = _load_font(26)
@@ -328,6 +332,16 @@ class CardBrickApp:
 
     # -- input ---------------------------------------------------------------------
 
+    def _open_joystick(self, device_index):
+        """Open a joystick and retain the reference (see __init__)."""
+        try:
+            joy = pygame.joystick.Joystick(device_index)
+        except pygame.error as exc:
+            log.error("could not open joystick %d: %s", device_index, exc)
+            return None
+        self._joysticks[joy.get_instance_id()] = joy
+        return joy
+
     def poll(self):
         """Next semantic action, or None.
 
@@ -345,11 +359,12 @@ class CardBrickApp:
             if event.type == pygame.QUIT:
                 raise QuitApp
             if event.type == pygame.JOYDEVICEADDED:
-                joy = pygame.joystick.Joystick(event.device_index)
-                joy.init()
-                log.info("joystick connected: %r", joy.get_name())
+                joy = self._open_joystick(event.device_index)
+                if joy:
+                    log.info("joystick connected: %r", joy.get_name())
                 continue
             if event.type == pygame.JOYDEVICEREMOVED:
+                self._joysticks.pop(event.instance_id, None)
                 log.warning("joystick disconnected")
                 continue
             action = self.input.translate(event)
@@ -1551,7 +1566,7 @@ class CardBrickApp:
                     if abs(event.value) > 0.5:
                         raw = f"axis {event.axis} value={event.value:+.2f}"
                 elif event.type == pygame.JOYDEVICEADDED:
-                    pygame.joystick.Joystick(event.device_index).init()
+                    self._open_joystick(event.device_index)
                     raw = "joystick connected"
                 if raw is not None:
                     semantic = self.input.translate(event)
@@ -1640,7 +1655,7 @@ class CardBrickApp:
                 log.info("calibration cancelled")
                 return "INPUT_DIAG"
             if event.type == pygame.JOYDEVICEADDED:
-                pygame.joystick.Joystick(event.device_index).init()
+                self._open_joystick(event.device_index)
             if event.type == pygame.JOYHATMOTION and \
                     event.value != (0, 0):
                 if semantic.startswith("dpad_"):

--- a/cardbrick-py/cardbrick/app.py
+++ b/cardbrick-py/cardbrick/app.py
@@ -280,6 +280,20 @@ class CardBrickApp:
     def run(self):
         if self.initial_state:
             state = self.initial_state
+        elif self.input_map.source == "defaults" and \
+                pygame.joystick.get_count() > 0:
+            # A joystick is present but never calibrated: the built-in
+            # DEFAULT_BUTTONS guess is only a starting point and is
+            # frequently wrong for a given device's raw SDL button
+            # order. Landing in Parent Menu with a wrong guess strands
+            # the child/parent on a screen that doesn't respond to any
+            # button — calibration has to come first so south_button
+            # (etc.) actually means something. Keyboard-only setups
+            # (desktop testing) skip this: KEYBOARD_SEMANTICS is fixed
+            # and never needs calibration.
+            log.warning("joystick present with no saved mapping — "
+                        "starting in controller setup")
+            state = "INPUT_DIAG"
         elif self._card_count() == 0:
             # Nothing imported yet: route straight to setup/parent mode.
             log.warning("no cards in database — starting in parent mode")

--- a/cardbrick-py/cardbrick/ui.py
+++ b/cardbrick-py/cardbrick/ui.py
@@ -91,8 +91,10 @@ class ReviewApp:
         self.screen = pygame.display.set_mode((SCREEN_W, SCREEN_H), flags)
         pygame.display.set_caption("CardBrick")
         pygame.mouse.set_visible(False)
-        for i in range(pygame.joystick.get_count()):
-            pygame.joystick.Joystick(i).init()
+        # Keep references: in pygame 2 a garbage-collected Joystick
+        # object closes the SDL device and its events stop arriving.
+        self._joysticks = [pygame.joystick.Joystick(i)
+                           for i in range(pygame.joystick.get_count())]
 
         self.font_big = _load_font(34)
         self.font = _load_font(24)


### PR DESCRIPTION
## Summary
Added logic to detect when a joystick/controller is connected but has no saved button mapping, and automatically route to the input calibration screen instead of the parent menu. This prevents users from being stranded on an unresponsive screen.

## Key Changes
- Added a new conditional branch in the `run()` method that checks if:
  - Input mapping is using default/uncalibrated buttons
  - A joystick device is physically present
- When both conditions are true, the app now starts in `INPUT_DIAG` (controller setup) state instead of the parent menu
- Keyboard-only setups (desktop testing) are unaffected since `KEYBOARD_SEMANTICS` doesn't require calibration
- Added a warning log message to inform users why the app is starting in controller setup

## Implementation Details
The fix addresses a UX issue where incorrect default button mappings for a specific controller would cause the app to start in an unresponsive state. By forcing calibration first when a joystick is detected without a saved mapping, users can properly configure their controller before proceeding to normal operation.

https://claude.ai/code/session_01RdSir99dM2BXm2oRHnH5Jf